### PR TITLE
image_manager: Add check for IBM extended version format

### DIFF
--- a/image_manager.cpp
+++ b/image_manager.cpp
@@ -21,6 +21,7 @@
 #include <ctime>
 #include <filesystem>
 #include <random>
+#include <regex>
 #include <string>
 
 namespace phosphor
@@ -198,6 +199,38 @@ int Manager::processImage(const std::string& tarFilePath)
     // Get ExtendedVersion
     std::string extendedVersion =
         Version::getValue(manifestPath.string(), "ExtendedVersion");
+
+    // Get the running Extended Version
+    std::string currExtendedVersion =
+        Version::getBMCExtendedVersion(OS_RELEASE_FILE);
+
+    // Check if the Extended Version have IBM's format of NNXXXX_YYY where NN
+    // is the platform identifier. This is a subcategory of machine name, check
+    // the second character and prevent the update if it doesn't match.
+    std::regex regex{"([A-Z]{1})([A-Z]{1})([0-9]{4})_([0-9]{3})",
+                     std::regex::extended};
+    std::smatch match;
+    if (std::regex_search(extendedVersion, match, regex))
+    {
+        auto platform = match[2].str();
+
+        if (std::regex_search(currExtendedVersion, match, regex))
+        {
+            auto currPlatform = match[2].str();
+
+            if (platform != currPlatform)
+            {
+                error("BMC upgrade: Platform name doesn't match: "
+                      "{CURRENT_PLATFORM} vs {NEW_PLATFORM}",
+                      "CURRENT_PLATFORM", currPlatform, "NEW_PLATFORM",
+                      platform);
+                report<ImageFailure>(
+                    ImageFail::FAIL("Platform name does not match"),
+                    ImageFail::PATH(manifestPath.string().c_str()));
+                return -1;
+            }
+        }
+    }
 
     // Get CompatibleNames
     std::vector<std::string> compatibleNames =


### PR DESCRIPTION
IBM sets the Extended Version to NNXXXX_YYY where NN is the platform
identifier (a subset of machine name). Add a check so that if Extended
Version matches this format, it checks that the platform is the same,
otherwise fail the same as with a machine name miscompare.

Tested:
- Verified a system running extended version NL failed to update
to an image with ML even though both have p10bmc as machine name:

.ExtendedVersion   property  s   "NL1030_007"

Aug 15 19:53:07 p10bmc phosphor-version-software-manager[1959]: BMC
upgrade: Platform name doesn't match: L vs M
Aug 15 19:53:07 p10bmc phosphor-version-software-manager[1959]: An error
occured processing the image.
Aug 15 19:53:07 p10bmc phosphor-version-software-manager[1959]: Error
(-1) processing image /tmp/images/01NM1030_007_007.tar

- Updates to an image with an Extended Version set to any other format
  that's not IBM's Extended Version format is allowed.

Change-Id: Ic2e20f5aa1a7062be3bea537d4b114cc412b56a6
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>