### PR TITLE
activation: Remove the BusyFailure error log 

### DIFF
--- a/activation.cpp
+++ b/activation.cpp
@@ -7,7 +7,6 @@
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
-#include <elog-errors.hpp>
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/elog.hpp>
 #include <phosphor-logging/lg2.hpp>
@@ -285,14 +284,7 @@ auto Activation::requestedActivation(RequestedActivations value)
         {
             if (parent.activationInProgress())
             {
-                namespace Software =
-                    phosphor::logging::xyz::openbmc_project::Software;
-                using Busy = Software::Image::BusyFailure;
-                using BusyFailure = sdbusplus::xyz::openbmc_project::Software::
-                    Image::Error::BusyFailure;
-                report<BusyFailure>(Busy::PATH(
-                    "xyz.openbmc_project.Software.Activation.Activations."
-                    "Ready"));
+                error("Another code update is already in progress");
                 utils::createBmcDump(bus);
                 Activation::activation(
                     softwareServer::Activation::Activations::Failed);


### PR DESCRIPTION
Just log a trace, since creating errors from a local yaml file and from
phosphor-dbus-interfaces in the same file is not supported.
A new Busy failure would need to be added to phoshpor-dbus-interfaces to
support logging an error.

Change-Id: I0c8e14c8ad5c5a37fbb62e3c2d2f0e6ecc4cd8ee
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>