### PR TITLE
Fix the core dump by using filesystem error_code

### DIFF
--- a/download_manager.cpp
+++ b/download_manager.cpp
@@ -15,6 +15,7 @@
 #include <filesystem>
 #include <iostream>
 #include <string>
+#include <system_error>
 
 namespace phosphor
 {
@@ -61,9 +62,11 @@ void Download::downloadViaTFTP(std::string fileName, std::string serverAddress)
 
     // Check if IMAGE DIR exists
     fs::path imgDirPath(IMG_UPLOAD_DIR);
-    if (!fs::is_directory(imgDirPath))
+    std::error_code ec;
+    if (!fs::is_directory(imgDirPath, ec))
     {
-        error("Image Dir {PATH} does not exist", "PATH", imgDirPath);
+        error("Image Dir {PATH} does not exist: {ERROR_MSG}", "PATH",
+              imgDirPath, "ERROR_MSG", ec.message());
         elog<InternalFailure>();
         return;
     }

--- a/serialize.cpp
+++ b/serialize.cpp
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <system_error>
 
 namespace phosphor
 {
@@ -24,16 +25,17 @@ const std::string purposeName = "purpose";
 
 void storePriority(const std::string& flashId, uint8_t priority)
 {
+    std::error_code ec;
     auto path = fs::path(PERSIST_DIR) / flashId;
-    if (!fs::is_directory(path))
+    if (!fs::is_directory(path, ec))
     {
-        if (fs::exists(path))
+        if (fs::exists(path, ec))
         {
             // Delete if it's a non-directory file
             warning("Removing non-directory file: {PATH}", "PATH", path);
-            fs::remove_all(path);
+            fs::remove_all(path, ec);
         }
-        fs::create_directories(path);
+        fs::create_directories(path, ec);
     }
     path = path / priorityName;
 
@@ -44,16 +46,17 @@ void storePriority(const std::string& flashId, uint8_t priority)
 
 void storePurpose(const std::string& flashId, VersionPurpose purpose)
 {
+    std::error_code ec;
     auto path = fs::path(PERSIST_DIR) / flashId;
-    if (!fs::is_directory(path))
+    if (!fs::is_directory(path, ec))
     {
-        if (fs::exists(path))
+        if (fs::exists(path, ec))
         {
             // Delete if it's a non-directory file
             warning("Removing non-directory file: {PATH}", "PATH", path);
-            fs::remove_all(path);
+            fs::remove_all(path, ec);
         }
-        fs::create_directories(path);
+        fs::create_directories(path, ec);
     }
     path = path / purposeName;
 
@@ -64,8 +67,9 @@ void storePurpose(const std::string& flashId, VersionPurpose purpose)
 
 bool restorePriority(const std::string& flashId, uint8_t& priority)
 {
+    std::error_code ec;
     auto path = fs::path(PERSIST_DIR) / flashId / priorityName;
-    if (fs::exists(path))
+    if (fs::exists(path, ec))
     {
         std::ifstream is(path.c_str(), std::ios::in);
         try
@@ -76,7 +80,7 @@ bool restorePriority(const std::string& flashId, uint8_t& priority)
         }
         catch (const cereal::Exception& e)
         {
-            fs::remove_all(path);
+            fs::remove_all(path, ec);
         }
     }
 
@@ -124,8 +128,9 @@ bool restorePriority(const std::string& flashId, uint8_t& priority)
 
 bool restorePurpose(const std::string& flashId, VersionPurpose& purpose)
 {
+    std::error_code ec;
     auto path = fs::path(PERSIST_DIR) / flashId / purposeName;
-    if (fs::exists(path))
+    if (fs::exists(path, ec))
     {
         std::ifstream is(path.c_str(), std::ios::in);
         try
@@ -136,7 +141,7 @@ bool restorePurpose(const std::string& flashId, VersionPurpose& purpose)
         }
         catch (const cereal::Exception& e)
         {
-            fs::remove_all(path);
+            fs::remove_all(path, ec);
         }
     }
 
@@ -145,10 +150,11 @@ bool restorePurpose(const std::string& flashId, VersionPurpose& purpose)
 
 void removePersistDataDirectory(const std::string& flashId)
 {
+    std::error_code ec;
     auto path = fs::path(PERSIST_DIR) / flashId;
-    if (fs::exists(path))
+    if (fs::exists(path, ec))
     {
-        fs::remove_all(path);
+        fs::remove_all(path, ec);
     }
 }
 

--- a/static/flash.cpp
+++ b/static/flash.cpp
@@ -9,6 +9,7 @@
 #include <phosphor-logging/lg2.hpp>
 
 #include <filesystem>
+#include <system_error>
 
 namespace
 {
@@ -52,8 +53,9 @@ void Activation::flashWrite()
 
     for (const auto& bmcImage : parent.imageUpdateList)
     {
+        std::error_code ec;
         fs::copy_file(uploadDir / versionId / bmcImage, toPath / bmcImage,
-                      fs::copy_options::overwrite_existing);
+                      fs::copy_options::overwrite_existing, ec);
     }
 }
 

--- a/sync_manager.cpp
+++ b/sync_manager.cpp
@@ -9,6 +9,7 @@
 #include <phosphor-logging/lg2.hpp>
 
 #include <filesystem>
+#include <system_error>
 
 namespace phosphor
 {
@@ -34,18 +35,19 @@ int Sync::processEntry(int mask, const fs::path& entryPath)
         // so need to differentiate between the different file events.
         if (mask & IN_CLOSE_WRITE)
         {
-            if (!(fs::exists(dst)))
+            std::error_code ec;
+            if (!(fs::exists(dst, ec)))
             {
-                if (fs::is_directory(entryPath))
+                if (fs::is_directory(entryPath, ec))
                 {
                     // Source is a directory, create it at the destination.
-                    fs::create_directories(dst);
+                    fs::create_directories(dst, ec);
                 }
                 else
                 {
                     // Source is a file, create the directory where this file
                     // resides at the destination.
-                    fs::create_directories(dst.parent_path());
+                    fs::create_directories(dst.parent_path(), ec);
                 }
             }
 

--- a/sync_watch.cpp
+++ b/sync_watch.cpp
@@ -9,6 +9,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <system_error>
 
 namespace phosphor
 {
@@ -53,8 +54,9 @@ SyncWatch::SyncWatch(sd_event& loop,
         return;
     }
 
+    std::error_code ec;
     auto syncfile = fs::path(SYNC_LIST_DIR_PATH) / SYNC_LIST_FILE_NAME;
-    if (fs::exists(syncfile))
+    if (fs::exists(syncfile, ec))
     {
         std::string line;
         std::ifstream file(syncfile.c_str());
@@ -98,7 +100,8 @@ int SyncWatch::callback(sd_event_source* /* s */, int fd, uint32_t revents,
         // Watch was removed, re-add it if file still exists.
         if (event->mask & IN_IGNORED)
         {
-            if (fs::exists(syncWatch->fileMap[event->wd]))
+            std::error_code ec;
+            if (fs::exists(syncWatch->fileMap[event->wd], ec))
             {
                 syncWatch->addInotifyWatch(syncWatch->fileMap[event->wd]);
             }

--- a/usb/usb_manager.cpp
+++ b/usb/usb_manager.cpp
@@ -4,6 +4,8 @@
 
 #include <sys/mount.h>
 
+#include <system_error>
+
 namespace phosphor
 {
 namespace usb
@@ -11,8 +13,9 @@ namespace usb
 
 bool USBManager::run()
 {
+    std::error_code ec;
     fs::path dir(usbPath);
-    fs::create_directories(dir);
+    fs::create_directories(dir, ec);
 
     auto rc = mount(devicePath.c_str(), usbPath.c_str(), "vfat", 0, NULL);
     if (rc)
@@ -27,7 +30,7 @@ bool USBManager::run()
         if (p.path().extension() == ".tar")
         {
             fs::path dstPath{IMG_UPLOAD_DIR / p.path().filename()};
-            if (fs::exists(dstPath))
+            if (fs::exists(dstPath, ec))
             {
                 lg2::info(
                     "{DSTPATH} already exists in the /tmp/images directory, exit the upgrade",

--- a/watch.cpp
+++ b/watch.cpp
@@ -14,6 +14,7 @@
 #include <filesystem>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 
 namespace phosphor
 {
@@ -30,10 +31,11 @@ Watch::Watch(sd_event* loop, std::function<int(std::string&)> imageCallback) :
     imageCallback(imageCallback)
 {
     // Check if IMAGE DIR exists.
+    std::error_code ec;
     fs::path imgDirPath(IMG_UPLOAD_DIR);
-    if (!fs::is_directory(imgDirPath))
+    if (!fs::is_directory(imgDirPath, ec))
     {
-        fs::create_directories(imgDirPath);
+        fs::create_directories(imgDirPath, ec);
     }
 
     fd = inotify_init1(IN_NONBLOCK);


### PR DESCRIPTION
The currently used filesystem method will cause an exception if the file system is damaged for some reason, resulting in a core dump of the process.
So the overloaded method with the error_code parameter should be used here to ensure that the process core dump will not be caused after an exception is thrown.

Fixes: openbmc/phosphor-bmc-code-mgmt#12

Tested: built phosphor-bmc-code-mgmt successfully and CI passes.

Signed-off-by: George Liu <liuxiwei@inspur.com>
Change-Id: I329f78b481cb466e755bc1b78562583620f561c2