### PR TITLE
1050: msl: reset: Set MSL to version of subsequent update (#51)

### DIFF
--- a/msl_verify.cpp
+++ b/msl_verify.cpp
@@ -11,12 +11,15 @@
 #include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/Software/Version/error.hpp>
 
+#include <filesystem>
 #include <regex>
 
 PHOSPHOR_LOG2_USING;
 using namespace phosphor::logging;
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+
+constexpr auto resetFile = "/tmp/reset-msl";
 
 int minimum_ship_level::compare(const Version& versionToCompare,
                                 const Version& mslVersion)
@@ -71,6 +74,25 @@ bool minimum_ship_level::verify(const std::string& versionManifest)
     //  If there is no msl or mslRegex return upgrade is needed.
     std::string msl{BMC_MSL};
     std::string mslRegex{REGEX_BMC_MSL};
+
+    // The MSL value was requested to be reset.
+    if (std::filesystem::exists(resetFile))
+    {
+        // Predefined reset msl version string
+        std::string resetStr{"fw1020.00-00"};
+        if (!mslRegex.empty())
+        {
+            std::smatch match;
+            std::regex rx{mslRegex, std::regex::extended};
+            if (std::regex_search(versionManifest, match, rx))
+            {
+                resetStr = match.str(0);
+            }
+        }
+        info("Resetting Minimum Ship Level to: {MSL}", "MSL", resetStr);
+        writeSystemKeyword(resetStr);
+    }
+
     if (msl.empty())
     {
         //  If the minimum level was not set as a compile-time option, check VPD
@@ -160,7 +182,12 @@ void minimum_ship_level::writeSystemKeyword(const std::string& value)
         "/xyz/openbmc_project/inventory/system/chassis/motherboard";
     constexpr auto vpdRecord = "VSYS";
     constexpr auto vpdKeyword = "FV";
+
+    // The VPD field is 32 bytes long and the default value is all 'spaces'. Pad
+    // the string with spaces to avoid leftover characters from a previous value
+    // that may had been longer.
     std::vector<uint8_t> vpdValue(value.begin(), value.end());
+    vpdValue.insert(vpdValue.end(), 32 - vpdValue.size(), ' ');
 
     try
     {
@@ -201,14 +228,10 @@ void minimum_ship_level::set()
     info("Current version: {VERSION}. Setting Minimum Ship Level to: {MSL}",
          "VERSION", version, "MSL", msl);
 
-    // The VPD field is 32 bytes long and the default value is all 'spaces'. Pad
-    // the string with spaces to avoid leftover characters from a previous value
-    // that may had been longer.
-    msl.append(32 - msl.length(), ' ');
     writeSystemKeyword(msl);
 }
 
 void minimum_ship_level::reset()
 {
-    writeSystemKeyword("fw1020.00-00");
+    std::ofstream outputFile(resetFile);
 }

--- a/msl_verify.hpp
+++ b/msl_verify.hpp
@@ -49,8 +49,10 @@ void writeSystemKeyword(const std::string& value);
  */
 void set();
 
-/** @brief Set the minimum ship level in VPD to the GA level to allow
- *         downgrades
+/** @brief Create a file to indicate the subsequent code update process to set
+ *         the minimum ship level to the image version used for the update.
+ *         Default this value to the GA level in case the image version does not
+ *         match the regex format.
  */
 void reset();
 


### PR DESCRIPTION
#### msl: reset: Set MSL to version of subsequent update (#51)
```
Currently, a MSL reset will write the GA level to VPD to allow all
downgrades to be performed.
Change it so that the reset request creates a temporary file that would
signal the code update process to write the MSL to the version of the
subsequent update. Therefore when a reset MSL is issued, and a system is
downgraded to the first service pack for example, it would write that
level to VPD, preventing further downgrades to the GA level.

Tested: Verified the reset MSL allowed a downgrade and that the level
was written to VPD.
- First check the downgrade is blocked:
Apr 04 18:26:32 p10bmc phosphor-image-updater[547]: BMC Minimum Ship
Level (fw1040.00-20                    ) NOT met by
fw1020.30-24-1020.2314.20230329a (NL1020_099)
- Issue reset request:
root@p10bmc:~# software-manager-tool --resetminlevel
- Retry the update:
Apr 04 18:27:23 p10bmc phosphor-image-updater[547]: Resetting Minimum
Ship Level to: fw1020.30-24
Apr 04 18:27:31 p10bmc systemd[1]: Starting Write image 86c7bbd9 to
BMC storage...

Change-Id: Ic37d977cfad720205ea13c3894458d4c7abb104a
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>```