### PR TITLE
Marker LID Validation : Define validation dbus interface Backend

### DIFF
--- a/activation.cpp
+++ b/activation.cpp
@@ -15,6 +15,7 @@
 #include <xyz/openbmc_project/Software/Image/error.hpp>
 #include <xyz/openbmc_project/Software/Version/error.hpp>
 
+#include <regex>
 #ifdef WANT_SIGNATURE_VERIFY
 #include "image_verify.hpp"
 #endif
@@ -38,6 +39,8 @@ PHOSPHOR_LOG2_USING;
 using namespace phosphor::logging;
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+using AccessKeyErr =
+    sdbusplus::xyz::openbmc_project::Software::Version::Error::ExpiredAccessKey;
 
 #ifdef WANT_SIGNATURE_VERIFY
 namespace control = sdbusplus::xyz::openbmc_project::Control::server;
@@ -100,21 +103,61 @@ auto Activation::activation(Activations value) -> Activations
     if (value == softwareServer::Activation::Activations::Activating)
     {
 #ifdef WANT_ACCESS_KEY_VERIFY
-        fs::path manifestPath(IMG_UPLOAD_DIR);
-        manifestPath /= (versionId + '/' + MANIFEST_FILE_NAME);
-
-        using UpdateAccessKey = phosphor::software::image::UpdateAccessKey;
-        UpdateAccessKey updateAccessKey(manifestPath);
-
-        updateAccessKey.sync();
-
-        if (!updateAccessKey.verify())
+        if (!std::filesystem::exists("/tmp/inband-update"))
         {
-            utils::createBmcDump(bus);
-            if (parent.control::FieldMode::fieldModeEnabled())
+            fs::path manifestPath(IMG_UPLOAD_DIR);
+            manifestPath /= (versionId + '/' + MANIFEST_FILE_NAME);
+
+            using UpdateAccessKey = phosphor::software::image::UpdateAccessKey;
+            UpdateAccessKey updateAccessKey(manifestPath);
+
+            using VersionClass = phosphor::software::manager::Version;
+            std::string versionID =
+                VersionClass::getValue(manifestPath.string(), "version");
+
+            // The release version is expected to be in the format of XXYYYY
+            // where YYYY is the release version, Ex: fw1050
+            std::string currVersion = versionID.substr(2, 4);
+
+            std::string buildID{};
+            std::size_t pos;
+            const std::regex pattern("\\d+-\\d+");
+            buildID = VersionClass::getValue(manifestPath.string(), "BuildId");
+            if (buildID.empty())
             {
-                return softwareServer::Activation::activation(
-                    softwareServer::Activation::Activations::Failed);
+                error("BMC build id is empty");
+            }
+
+            if (std::regex_match(buildID, pattern))
+            {
+                isHiper = true;
+                pos = buildID.find_first_of("-") + 1;
+                buildID = buildID.substr(pos);
+            }
+
+            updateAccessKey.sync();
+
+            try
+            {
+                if (!updateAccessKey.verify(buildID, currVersion, isHiper))
+                {
+                    utils::createBmcDump(bus);
+                    if (parent.control::FieldMode::fieldModeEnabled())
+                    {
+                        return softwareServer::Activation::activation(
+                            softwareServer::Activation::Activations::Failed);
+                    }
+                }
+            }
+            catch (AccessKeyErr& e)
+            {
+                commit<AccessKeyErr>();
+                utils::createBmcDump(bus);
+                if (parent.control::FieldMode::fieldModeEnabled())
+                {
+                    return softwareServer::Activation::activation(
+                        softwareServer::Activation::Activations::Failed);
+                }
             }
         }
 #endif

--- a/activation.hpp
+++ b/activation.hpp
@@ -348,6 +348,9 @@ class Activation : public ActivationInherit, public Flash
 
     /** @brief Called when image verification fails. */
     void onVerifyFailed();
+
+    /** @brief flag to indicate if service pack is HIPER*/
+    bool isHiper = false;
 #endif
 };
 

--- a/gen-lids-image-tar
+++ b/gen-lids-image-tar
@@ -43,6 +43,10 @@ rm -fr $TAR_IMAGE_PATH
 echo "Executing tar -cf $TAR_IMAGE_PATH . -C $UPDATE_DIR_PATH"
 tar -cf $TAR_IMAGE_PATH . -C $UPDATE_DIR_PATH
 
+#Create a temporary file to indicate that the update is am inband code update, this is required during activation
+#as the UAK verification is already done.
+touch /tmp/inband-update
+
 #Copy the tarball to the update directory to trigger the phosphor software manager to create a version interface
 cp $TAR_IMAGE_PATH $UPDATE_IMAGE_PATH
 

--- a/lid.cpp
+++ b/lid.cpp
@@ -5,10 +5,15 @@
 #include "utils.hpp"
 #include "version.hpp"
 
+#include <arpa/inet.h>
+
 #include <elog-errors.hpp>
 #include <phosphor-logging/elog.hpp>
 #include <phosphor-logging/lg2.hpp>
 
+#include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <string>
 
 #ifdef WANT_ACCESS_KEY_VERIFY
@@ -24,13 +29,116 @@ namespace manager
 namespace server = sdbusplus::xyz::openbmc_project::Software::server;
 using VersionClass = phosphor::software::manager::Version;
 PHOSPHOR_LOG2_USING;
+using namespace phosphor::logging;
+using namespace sdbusplus::xyz::openbmc_project::Software::Image::Error;
+using namespace phosphor::software::image;
+namespace Software = phosphor::logging::xyz::openbmc_project::Software;
+namespace fs = std::filesystem;
+using VersionClass = phosphor::software::manager::Version;
 
 void Lid::validate(std::string filePath)
 {
 #ifdef WANT_ACCESS_KEY_VERIFY
+    struct markerLid
+    {
+        uint32_t versionId;
+        uint32_t offsetToMIKeywordSection;
+        uint32_t offsetToIseriesMarker;
+        uint32_t sizeOfMiKeyword;
+        char miKeyword[40];
+        char lastDisruptiveApplyFixLevel[3];
+        char lastDisruptiveActivationFSP[3];
+        char lastdisruptiveActivationPHYP[3];
+        char lastDisruptiveActivationPFW[3];
+        char lastChangedFixLevelForFSP[3];
+        char lastChangedFixLevelForPHYP[3];
+        char lastChangedFixLevelForPFW[3];
+        char reserved[3];
+        uint32_t offsetToAdditionalDataFields;
+    };
+    markerLid ml;
 
-    info("Update access key verification passed, {PATH}:", "PATH", filePath);
+    typedef struct
+    {
+        uint32_t SPFlagsOffset;
+        uint32_t SPFlagsSize;
+        uint32_t SPDateOffset;
+        uint32_t SPDateSize;
+    } markerFwIPAdfHeader_t;
 
+    typedef struct
+    {
+        uint32_t SPFlags;
+        char SPDate[9];
+    } fippAdfData_t;
+
+    // Open the Marker LID file and copy contents to the markerLid structure
+    std::ifstream efile(filePath, std::ios::in | std::ios::binary);
+    efile.read(reinterpret_cast<char*>(&ml), sizeof(ml));
+
+    using UpdateAccessKey = phosphor::software::image::UpdateAccessKey;
+    UpdateAccessKey updateAccessKey("");
+    uint32_t offBuff = htonl(ml.offsetToAdditionalDataFields);
+    uint32_t adfCount;
+    uint32_t adfSize;
+    uint32_t adfSignature;
+    markerFwIPAdfHeader_t markerFippAdfHeader;
+    std::string gaDate{};
+    std::string version{};
+
+    // Read the total number of ADFs present in the Marker LID file
+    efile.seekg(offBuff, efile.beg);
+    efile.read(reinterpret_cast<char*>(&adfCount), sizeof(adfCount));
+
+    // Loop through the ADFs to find respective ADF
+    for (uint8_t i = 0; i < htonl(adfCount); i++)
+    {
+        // Read the Size of ADF
+        efile.read(reinterpret_cast<char*>(&adfSize), sizeof(adfSize));
+
+        // Read the ADF signature Eg: FIPP, DSPNM, I5FX, HMCV, SECV etc
+        efile.read(reinterpret_cast<char*>(&adfSignature),
+                   sizeof(adfSignature));
+
+        // If the ADF is FIPP aka the firmware IP ADF
+        if (htonl(adfSignature) == markerAdfFippSig)
+        {
+            fippAdfData_t fippData;
+
+            // Read the ADF header into markerFippAdfHeader structure
+            efile.read(reinterpret_cast<char*>(&markerFippAdfHeader),
+                       sizeof(markerFippAdfHeader));
+
+            // Reading SP flag which indicates weather the service pack is an
+            // emergency service pack or one off service
+            efile.read(reinterpret_cast<char*>(&fippData.SPFlags),
+                       sizeof(fippData.SPFlags));
+
+            // Reading the GA date or the date when the service pack was
+            // released
+            efile.read(fippData.SPDate, sizeof(fippData.SPDate));
+
+            if (htonl(fippData.SPFlags) == hiperSPFlag)
+            {
+                isHiper = true;
+            }
+
+            gaDate = fippData.SPDate;
+
+            version = std::string(&ml.miKeyword[2], &ml.miKeyword[6]);
+            // Calling the UAK verify method
+            updateAccessKey.verify(gaDate, version, isHiper);
+            isHiper = false;
+            break;
+        }
+        else
+        {
+            // seek to the next ADF in the Marker LID
+            uint32_t nextADFOff = htonl(adfSize) - sizeof(adfSize) -
+                                  sizeof(adfSignature);
+            efile.seekg(nextADFOff, efile.cur);
+        }
+    }
 #endif
     return;
 }

--- a/lid.hpp
+++ b/lid.hpp
@@ -14,6 +14,8 @@ namespace software
 namespace manager
 {
 
+static constexpr uint32_t markerAdfFippSig = 0x46495050; // "FIPP"
+static constexpr uint32_t hiperSPFlag = 0x40000000;
 using LidInherit = sdbusplus::server::object_t<
     sdbusplus::xyz::openbmc_project::Software::server::LID>;
 namespace sdbusRule = sdbusplus::bus::match::rules;
@@ -35,6 +37,7 @@ class Lid : public LidInherit
     /**
      * @brief Validator for inband update
      *
+     * @param[in] filePath - file path to the Marker LID file
      */
     void validate(std::string filePath);
     /**
@@ -44,6 +47,8 @@ class Lid : public LidInherit
     void assembleCodeUpdateImage();
 
   private:
+    bool isHiper = false;
+
     sdbusplus::bus_t& bus;
     /** @brief Used to subscribe to dbus systemd signals **/
     sdbusplus::bus::match_t systemdSignals;

--- a/uak_verify.cpp
+++ b/uak_verify.cpp
@@ -3,6 +3,7 @@
 #include "uak_verify.hpp"
 
 #include "utils.hpp"
+#include "version.hpp"
 
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <phosphor-logging/elog-errors.hpp>
@@ -27,6 +28,12 @@ namespace image
 {
 PHOSPHOR_LOG2_USING;
 
+using namespace phosphor::logging;
+using VersionClass = phosphor::software::manager::Version;
+using AccessKeyErr =
+    sdbusplus::xyz::openbmc_project::Software::Version::Error::ExpiredAccessKey;
+using ExpiredAccessKey =
+    xyz::openbmc_project::Software::Version::ExpiredAccessKey;
 std::string UpdateAccessKey::getUpdateAccessExpirationDate(
     const std::string& objectPath)
 {
@@ -84,64 +91,14 @@ void UpdateAccessKey::writeUpdateAccessExpirationDate(
     }
 }
 
-std::string UpdateAccessKey::getBuildID()
-{
-    std::string buildIDKey = "BuildId";
-    std::string buildIDValue{};
-    std::string buildID{};
-
-    std::ifstream efile(manifestPath);
-    std::string line;
-
-    while (getline(efile, line))
-    {
-        if (line.substr(0, buildIDKey.size()).find(buildIDKey) !=
-            std::string::npos)
-        {
-            buildIDValue = line.substr(buildIDKey.size());
-            std::size_t pos = buildIDValue.find_first_of('=') + 1;
-            buildID = buildIDValue.substr(pos);
-            break;
-        }
-    }
-    efile.close();
-
-    if (buildID.empty())
-    {
-        error("BMC build id is empty");
-    }
-
-    return buildID;
-}
-
-bool UpdateAccessKey::verify()
+bool UpdateAccessKey::checkIfUAKValid(const std::string& buildID)
 {
     constexpr auto motherboardObjectPath =
         "/xyz/openbmc_project/inventory/system/chassis/motherboard";
-    std::string expirationDate{};
-    std::string buildID{};
-    buildID = getBuildID();
     expirationDate = getUpdateAccessExpirationDate(motherboardObjectPath);
-
     // Ensure that BUILD_ID date is in the YYYYMMDD format but truncating the
     // string to a length of 8 characters--excluding build's time information.
-    std::string buildIDTrunc = buildID.substr(0, 8);
-
-    // If BuildID value is the designated value of 00000000, that means the
-    // image being updated is an emergency service pack and should bypass the
-    // UAK check.
-
-    if (buildIDTrunc == "00000000")
-    {
-        debug("Access Key valid. BMC will begin activating.");
-        return true;
-    }
-
-    using namespace phosphor::logging;
-    using AccessKeyErr = sdbusplus::xyz::openbmc_project::Software::Version::
-        Error::ExpiredAccessKey;
-    using ExpiredAccessKey =
-        xyz::openbmc_project::Software::Version::ExpiredAccessKey;
+    buildIDTrunc = buildID.substr(0, 8);
 
     try
     {
@@ -159,8 +116,6 @@ bool UpdateAccessKey::verify()
             "Update Access Key validation failed. Expiration Date: {EXP_DATE}. "
             "Build date: {BUILD_ID}.",
             "EXP_DATE", expirationDate, "BUILD_ID", buildIDTrunc);
-        report<AccessKeyErr>(ExpiredAccessKey::EXP_DATE(expirationDate.c_str()),
-                             ExpiredAccessKey::BUILD_ID(buildIDTrunc.c_str()));
         return false;
     }
     catch (...)
@@ -169,10 +124,38 @@ bool UpdateAccessKey::verify()
             "Update Access Key validation failed. Expiration Date: {EXP_DATE}. "
             "Build date: {BUILD_ID}.",
             "EXP_DATE", expirationDate, "BUILD_ID", buildIDTrunc);
-        report<AccessKeyErr>(ExpiredAccessKey::EXP_DATE(expirationDate.c_str()),
-                             ExpiredAccessKey::BUILD_ID(buildIDTrunc.c_str()));
+        return false;
     }
-    return false;
+}
+bool UpdateAccessKey::verify(const std::string& gaDate,
+                             const std::string& version, bool isHiper)
+{
+    std::string expirationDate{};
+    std::string buildID{};
+    buildID = gaDate;
+
+    if (!checkIfUAKValid(buildID))
+    {
+        std::string versionID = VersionClass::getBMCVersion(OS_RELEASE_FILE);
+        // skip the first two characters to get the GA level
+        std::string currVersion = versionID.substr(2, 4);
+        if (isHiper && (version.compare(currVersion) == 0))
+        {
+            return true;
+        }
+        else
+        {
+            error(
+                "Update Access Key validation failed. Expiration Date: {EXP_DATE}. "
+                "Build date: {BUILD_ID}.",
+                "EXP_DATE", expirationDate, "BUILD_ID", buildIDTrunc);
+            elog<AccessKeyErr>(
+                ExpiredAccessKey::EXP_DATE(expirationDate.c_str()),
+                ExpiredAccessKey::BUILD_ID(buildIDTrunc.c_str()));
+            return false;
+        }
+    }
+    return true;
 }
 
 void UpdateAccessKey::sync()

--- a/uak_verify.hpp
+++ b/uak_verify.hpp
@@ -28,10 +28,24 @@ class UpdateAccessKey
     UpdateAccessKey(const fs::path& manifestPath) : manifestPath(manifestPath)
     {}
 
+    /** @brief Method to verify if the UAK of the service pack is valid
+     *
+     *  @param[in] buildID - build ID of the service pack
+     *
+     *  @return true if the UAK is valid
+     */
+    bool checkIfUAKValid(const std::string& buildID);
+
     /** @brief Verify if the current image BUILD_ID meet the access key criteria
+     *
+     *  @param[in] gaDate - the GA date of the service pack
+     *  @param[in] version - version/G level of the service pack
+     *  @param[in] isHiper - flag to indicate if the SP is a HIPER service pack
+     *
      *  @return true if the verification succeeded, false otherwise
      */
-    bool verify();
+    bool verify(const std::string& gaDate, const std::string& version,
+                bool isHiper);
 
     /** @brief Syncs the update access key found in VPD and flash memory */
     void sync();
@@ -51,13 +65,11 @@ class UpdateAccessKey
     void writeUpdateAccessExpirationDate(const std::string& date,
                                          const std::string& objectPath);
 
-    /** @brief Get the BMC build_id string from the manifest file
-     *  @return The build_id.
-     */
-    std::string getBuildID();
-
     /** @brief Manifest file path */
     fs::path manifestPath;
+
+    std::string buildIDTrunc{};
+    std::string expirationDate{};
 };
 
 } // namespace image


### PR DESCRIPTION
This commit defines the dbus interface “validate” that will be called during inband code updates. As of now, the interface checks the validity of the access key. If the access key has expired and field mode is enabled, the dbus returns an error specifying the problem.

This commit also adds restriction on HIPER service packs, being
allowed across GA levels. HIPER service packs only within the same
GA level will be allowed to be updated.
Example: If a customer is on a build with the GA level of fw1030, they
cannot move to the HIPER service pack released for fw1050.

Previously, HIPER service packs could be applied across GA levels
and this allowed customers to utilize the features of a latter service
pack without buying the service contract.

Tested:
Used busctl call “busctl call xyz.openbmc_project.Software.BMC.Updater /xyz/openbmc_project/software xyz.openbmc_project.LID.Validate Validate s /media/hostfw/running-ro/80a00001.lid” to ensure that the call performs the validation call and the appropriate returns and errors are logged.