### PR TITLE
1050: systemd: no installation in templated targets

### DIFF
--- a/side-switch/phosphor-bmc-side-switch.service
+++ b/side-switch/phosphor-bmc-side-switch.service
@@ -19,4 +19,4 @@ RemainAfterExit=no
 ExecStart=/usr/bin/phosphor-bmc-side-switch
 
 [Install]
-WantedBy=obmc-host-startmin@0.target
+#WantedBy=obmc-host-startmin@0.target


### PR DESCRIPTION
#### systemd: no installation in templated targets
```
Upstream yocto introduced a change via e510222 (systemd-systemctl:
fix instance template WantedBy symlink construction).

This fixes a bug that we in OpenBMC had been taking advantage of in that
we were able to document our templated target dependencies without it
actually doing anything. The real installation of services within
targets occurs in our bitbake recipes due to the complexity of chassis
and host instances on a per machine basis.

Leave the dependency information in the service files but comment them
out. It's useful to be able to look at a service and understand which
targets it's going to be installed into by the bitbake recipes.

In some cases, we had hard coded the target instance, which does install
the service correctly, but only in that one target. All services should
be installed via the bitbake recipe to ensure the service is properly
installed in all instances of the target. Once the bump for this commit
goes into openbmc/openbmc, I will ensure the recipe is updated to
install all services correctly.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: I401f988e92efb37f4928b14433b9d3035ec462d5
```