### PR TITLE
mmc: Run fsck on the alternate image and hostfw

### DIFF
--- a/mmc/obmc-flash-mmc-mount.service.in
+++ b/mmc/obmc-flash-mmc-mount.service.in
@@ -7,6 +7,7 @@ Type=oneshot
 RemainAfterExit=no
 ExecStart=/usr/bin/obmc-flash-bmc mmc-mount @MEDIA_DIR@
 ExecStart=/bin/mkdir -p @MEDIA_DIR@/hostfw
+ExecStart=-/sbin/fsck.ext4 -p /dev/disk/by-partlabel/hostfw
 ExecStart=-/bin/mount PARTLABEL=hostfw @MEDIA_DIR@/hostfw -t ext4
 
 [Install]

--- a/obmc-flash-bmc
+++ b/obmc-flash-bmc
@@ -547,6 +547,13 @@ function mmc_mount() {
     primaryDir="${mediaDir}/rofs-${primaryId}-functional"
     secondaryDir="${mediaDir}/rofs-${secondaryId}"
 
+    # Check the alternate version, remove it if it's corrupted. This can occur
+    # when the BMC is rebooted in the middle of a code update for example.
+    if ! fsck.ext4 -p "/dev/disk/by-partlabel/rofs-${secondaryId}"; then
+        flashid="${secondaryId}"
+        mmc_remove
+    fi
+
     mkdir -p "${primaryDir}"
     mkdir -p "${secondaryDir}"
 


### PR DESCRIPTION
Before mounting the alternate image, run fsck on it to determine if the filesystem is corrupted, this could happen if the BMC rebooted in the middle of a code update for example. Invalidate the image if it's found to be corrupted.

Run fsck on the hostfw partition too, this is a writable partition that can benefit from autocorrection. The mmc initramfs runs fsck on the rwfs partition already. It's a good practice to run fsck on writable partitions. Do not fail if fsck fails on the hostfw partition, if it's corrupted, an error would occur during the power on.

Tested: Verified there were no errors with this change. This change adds about 1s to the execution of the mount service, from 5s to 6s to start:

May 24 19:07:27 p10bmc systemd[1]: Starting Mount BMC rofs volumes after a reboot...
May 24 19:07:27 p10bmc obmc-flash-bmc[328]:
/dev/disk/by-partlabel/rofs-a: clean, 6430/68816 files, 192421/275012 blocks
May 24 19:07:27 p10bmc kernel: EXT4-fs (mmcblk0p4): mounted filesystem with ordered data mode. Quota mode: disabled. May 24 19:07:33 p10bmc fsck.ext4[474]: hostfw: clean, 247/655360 files, 196363/1310720 blocks
May 24 19:07:34 p10bmc kernel: EXT4-fs (mmcblk0p7): mounted filesystem with ordered data mode. Quota mode: disabled. May 24 19:07:34 p10bmc systemd[1]: obmc-flash-mmc-mount.service: Deactivated successfully.
May 24 19:07:34 p10bmc systemd[1]: Finished Mount BMC rofs volumes after a reboot.

Change-Id: I0efedb6d72e1d0d6018974598c4b361eafe7441b