### PR TITLE
Marker LID Validation: Add minimum ship level check

### DIFF
--- a/activation.cpp
+++ b/activation.cpp
@@ -41,6 +41,8 @@ using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
 using AccessKeyErr =
     sdbusplus::xyz::openbmc_project::Software::Version::Error::ExpiredAccessKey;
+using IncompatibleErr =
+    sdbusplus::xyz::openbmc_project::Software::Version::Error::Incompatible;
 
 #ifdef WANT_SIGNATURE_VERIFY
 namespace control = sdbusplus::xyz::openbmc_project::Control::server;
@@ -181,11 +183,28 @@ auto Activation::activation(Activations value) -> Activations
 
         auto versionStr = parent.versions.find(versionId)->second->version();
 
-        if (!minimum_ship_level::verify(versionStr))
+        // Perform minimum ship validation if this is not an inband update or if
+        // the reset msl has been requested since an inband update does not
+        // reset the msl value.
+        if ((!std::filesystem::exists("/tmp/inband-update")) ||
+            (std::filesystem::exists(minimum_ship_level::resetFile)))
         {
-            utils::createBmcDump(bus);
-            return softwareServer::Activation::activation(
-                softwareServer::Activation::Activations::Failed);
+            try
+            {
+                if (!minimum_ship_level::verify(versionStr))
+                {
+                    utils::createBmcDump(bus);
+                    return softwareServer::Activation::activation(
+                        softwareServer::Activation::Activations::Failed);
+                }
+            }
+            catch (IncompatibleErr& e)
+            {
+                commit<IncompatibleErr>();
+                utils::createBmcDump(bus);
+                return softwareServer::Activation::activation(
+                    softwareServer::Activation::Activations::Failed);
+            }
         }
 
         if (!activationProgress)

--- a/lid.hpp
+++ b/lid.hpp
@@ -15,6 +15,7 @@ namespace manager
 {
 
 static constexpr uint32_t markerAdfFippSig = 0x46495050; // "FIPP"
+static constexpr uint32_t markerAdfSpnmSig = 0x53504E4D; // "SPNM"
 static constexpr uint32_t hiperSPFlag = 0x40000000;
 using LidInherit = sdbusplus::server::object_t<
     sdbusplus::xyz::openbmc_project::Software::server::LID>;

--- a/msl_verify.cpp
+++ b/msl_verify.cpp
@@ -19,8 +19,6 @@ using namespace phosphor::logging;
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
 
-constexpr auto resetFile = "/tmp/reset-msl";
-
 int minimum_ship_level::compare(const Version& versionToCompare,
                                 const Version& mslVersion)
 {
@@ -133,9 +131,9 @@ bool minimum_ship_level::verify(const std::string& versionManifest)
             "BMC Minimum Ship Level ({MIN_VERSION}) NOT met by {ACTUAL_VERSION}",
             "MIN_VERSION", msl, "ACTUAL_VERSION", tmpStr, "VERSION_PURPOSE",
             purpose);
-        report<IncompatibleErr>(Incompatible::MIN_VERSION(msl.c_str()),
-                                Incompatible::ACTUAL_VERSION(tmpStr.c_str()),
-                                Incompatible::VERSION_PURPOSE(purpose.c_str()));
+        elog<IncompatibleErr>(Incompatible::MIN_VERSION(msl.c_str()),
+                              Incompatible::ACTUAL_VERSION(tmpStr.c_str()),
+                              Incompatible::VERSION_PURPOSE(purpose.c_str()));
         return false;
     }
 

--- a/msl_verify.hpp
+++ b/msl_verify.hpp
@@ -5,6 +5,8 @@
 namespace minimum_ship_level
 {
 
+constexpr auto resetFile = "/tmp/reset-msl";
+
 /** @brief Version components */
 struct Version
 {


### PR DESCRIPTION
Perform the minimum ship level check as part of the marker lid validation. This requires reading the SPNM ADF to get the firmware version string.

Move the UAK variables to the ifdef block that validates the UAK to avoid compile errors from platforms that don't have UAK check enabled.

Tested:
- Inband:
```
Aug 06 19:13:15 p10bmc phosphor-image-updater[537]: BMC Minimum Ship Level (fw1050.10-00                    ) NOT met by fw1050.00-99
Aug 06 19:13:15 p10bmc pldmd[1436]: Marker lid validate error, ERROR=sd_bus_call: xyz.openbmc_project.Software.Version.Error.Incompatible: A system component has a software version that is incompatible as determined by the implementation and needs to be updated. Some usage examples for this error include creating logging events and providing information on implementation reactions such as when the system is prevented from powering on if a minimum version level is not met.
Aug 06 19:13:15 p10bmc pldmd[1436]: 80 02 0a 01 01 00 19 00 01 00 01 00
Aug 06 19:13:15 p10bmc phosphor-image-updater[537]: A system component has a software version that is incompatible as determined by the implementation and needs to be updated. Some usage examples for this error include creating logging events and providing information on implementation reactions such as when the system is prevented from powering on if a minimum version level is not met.
```

- Inband with bypass:
```
Aug 06 19:14:36 p10bmc pldmd[1436]: 80 02 0a 01 01 00 19 00 01 00 00 00
...
Aug 06 19:18:05 p10bmc phosphor-image-updater[537]: Resetting Minimum Ship Level to: fw1050.00-4
```

- Out of band:
```
Aug 06 19:26:00 p10bmc phosphor-image-updater[538]: BMC Minimum Ship Level (fw1050.10-00                    ) NOT met by fw1050.00-4.23-3-g6860385b88
Aug 06 19:26:00 p10bmc phosphor-image-updater[538]: A system component has a software version that is incompatible as determined by the implementation and needs to be updated. Some usage examples for this error include creating logging events and providing information on implementation reactions such as when the system is prevented from powering on if a minimum version level is not met.
Aug 06 19:26:00 p10bmc phosphor-log-manager[344]: Created PEL 0x50011595 (BMC ID 2002) with SRC BD8D3601
```

- Out of band with bypass:
```
Aug 06 19:26:56 p10bmc phosphor-image-updater[538]: Resetting Minimum Ship Level to: fw1050.00-4
```

Change-Id: I7fc3fe886ad52f1842eabc6f90d91492924d63fe