### PR TITLE
Increased UAK enforcement

### DIFF
--- a/activation.cpp
+++ b/activation.cpp
@@ -119,7 +119,7 @@ auto Activation::activation(Activations value) -> Activations
 
             // The release version is expected to be in the format of XXYYYY
             // where YYYY is the release version, Ex: fw1050
-            std::string currVersion = versionID.substr(2, 4);
+            std::string currVersion = versionID.substr(2, 7);
 
             std::string buildID{};
             std::size_t pos;
@@ -132,7 +132,7 @@ auto Activation::activation(Activations value) -> Activations
 
             if (std::regex_match(buildID, pattern))
             {
-                isHiper = true;
+                isOneOff = true;
                 pos = buildID.find_first_of("-") + 1;
                 buildID = buildID.substr(pos);
             }
@@ -141,7 +141,7 @@ auto Activation::activation(Activations value) -> Activations
 
             try
             {
-                if (!updateAccessKey.verify(buildID, currVersion, isHiper))
+                if (!updateAccessKey.verify(buildID, currVersion, isOneOff))
                 {
                     utils::createBmcDump(bus);
                     if (parent.control::FieldMode::fieldModeEnabled())

--- a/activation.hpp
+++ b/activation.hpp
@@ -349,8 +349,8 @@ class Activation : public ActivationInherit, public Flash
     /** @brief Called when image verification fails. */
     void onVerifyFailed();
 
-    /** @brief flag to indicate if service pack is HIPER*/
-    bool isHiper = false;
+    /** @brief flag to indicate if service pack is a One Off*/
+    bool isOneOff = false;
 #endif
 };
 

--- a/lid.hpp
+++ b/lid.hpp
@@ -16,7 +16,7 @@ namespace manager
 
 static constexpr uint32_t markerAdfFippSig = 0x46495050; // "FIPP"
 static constexpr uint32_t markerAdfSpnmSig = 0x53504E4D; // "SPNM"
-static constexpr uint32_t hiperSPFlag = 0x40000000;
+static constexpr uint32_t oneOffSPFlag = 0x80000000;
 using LidInherit = sdbusplus::server::object_t<
     sdbusplus::xyz::openbmc_project::Software::server::LID>;
 namespace sdbusRule = sdbusplus::bus::match::rules;
@@ -48,7 +48,8 @@ class Lid : public LidInherit
     void assembleCodeUpdateImage();
 
   private:
-    bool isHiper = false;
+    std::string fwVersion;
+    bool isOneOff = false;
 
     sdbusplus::bus_t& bus;
     /** @brief Used to subscribe to dbus systemd signals **/

--- a/uak_verify.hpp
+++ b/uak_verify.hpp
@@ -40,12 +40,13 @@ class UpdateAccessKey
      *
      *  @param[in] gaDate - the GA date of the service pack
      *  @param[in] version - version/G level of the service pack
-     *  @param[in] isHiper - flag to indicate if the SP is a HIPER service pack
+     *  @param[in] isOneOff - flag to indicate if the SP is a One Off service
+     *  pack
      *
      *  @return true if the verification succeeded, false otherwise
      */
     bool verify(const std::string& gaDate, const std::string& version,
-                bool isHiper);
+                bool isOneOff);
 
     /** @brief Syncs the update access key found in VPD and flash memory */
     void sync();


### PR DESCRIPTION
Change makes HIPER flag in marker lid independent of UAK enforcement
     • UAK must be enforced on any X movement on FW10NN.XY
     • UAK is not enforced on any Y movement on FW10NN.XY
     • If the "one off" flag is set then UAK enforcement is ignored