### PR TITLE
1060: Increased UAK enforcement on X movement (#26)

### DIFF
--- a/uak_verify.cpp
+++ b/uak_verify.cpp
@@ -153,6 +153,7 @@ bool UpdateAccessKey::verify(const std::string& gaDate,
 
             std::string currMinorVersion = currVersion.substr(dotPosition + 1);
             int currentMinorVersion = stoi(currMinorVersion);
+            int currentMinorVersionX = currentMinorVersion / 10;
 
             dotPosition = version.find('.');
             std::string tarMajorVersion = version.substr(0, dotPosition);
@@ -160,9 +161,10 @@ bool UpdateAccessKey::verify(const std::string& gaDate,
 
             std::string tarMinorVersion = version.substr(dotPosition + 1);
             int targetMinorVersion = stoi(tarMinorVersion);
+            int targetMinorVersionX = targetMinorVersion / 10;
 
             if (((targetMajorVersion == currentMajorVersion) &&
-                 (targetMinorVersion <= currentMinorVersion)) ||
+                 (targetMinorVersionX <= currentMinorVersionX)) ||
                 isOneOff || (targetMajorVersion < currentMajorVersion))
             {
                 return true;


### PR DESCRIPTION
#### Increased UAK enforcement on X movement (#26)
```
In the current code, UAK is not enforced on X movement
on a 10NN.XY build as part of the changes that was
merged for 1M4 line item:
https://github.com/ibm-openbmc/phosphor-bmc-code-mgmt/pull/23

This commit fixes it and adds enforcement on X movement and
not on the Y movement.

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>```