### PR TITLE
Add bypass in code updates for machine name

### DIFF
--- a/image_manager.cpp
+++ b/image_manager.cpp
@@ -158,7 +158,9 @@ int Manager::processImage(const std::string& tarFilePath)
                                                "MachineName");
     if (!machineStr.empty())
     {
-        if (machineStr != currMachine)
+        // If ignoreMachineName is set then let the update continue
+        if (!std::filesystem::exists("/tmp/ignore-machine-name") &&
+            machineStr != currMachine)
         {
             error(
                 "BMC upgrade: Machine name doesn't match: {CURRENT_MACHINE} vs {NEW_MACHINE}",
@@ -221,7 +223,9 @@ int Manager::processImage(const std::string& tarFilePath)
         {
             auto currPlatform = match[2].str();
 
-            if (platform != currPlatform)
+            // If ignoreMachineName is set then let the update continue
+            if (!std::filesystem::exists("/tmp/ignore-machine-name") &&
+                platform != currPlatform)
             {
                 error("BMC upgrade: Platform name doesn't match: "
                       "{CURRENT_PLATFORM} vs {NEW_PLATFORM}",

--- a/software_manager_tool.cpp
+++ b/software_manager_tool.cpp
@@ -8,12 +8,16 @@ int main(int argc, char** argv)
 
     bool setMinLevel = false;
     bool resetMinLevel = false;
+    bool ignoreMachineName = false;
 
     app.add_flag(
         "--setminlevel", setMinLevel,
         "Set the minimum ship level to the running version of the system");
     app.add_flag("--resetminlevel", resetMinLevel,
                  "Reset the minimum ship level to allow a firmware dowgrade");
+    app.add_flag(
+        "--ignore_machine_name", ignoreMachineName,
+        "Ignore the machine type to allow a firmware upgrade in the lab. For lab and testing purposes only.");
 
     CLI11_PARSE(app, argc, argv);
 
@@ -24,6 +28,10 @@ int main(int argc, char** argv)
     else if (resetMinLevel)
     {
         minimum_ship_level::reset();
+    }
+    else if (ignoreMachineName)
+    {
+        std::ofstream outputFile("/tmp/ignore-machine-name");
     }
     else
     {


### PR DESCRIPTION
This is to allow P10 systems to be updated to P-Future images and vice versa.

Tested on simics. With this change, running `software-manager-tool --ignore_machine_name` allows the update to go ahead with an image with a different machine name field.