### PR TITLE
1050: Populate MinimumVersion property

### DIFF
--- a/item_updater.hpp
+++ b/item_updater.hpp
@@ -3,6 +3,7 @@
 #include "activation.hpp"
 #include "item_updater_helper.hpp"
 #include "lid.hpp"
+#include "msl_verify.hpp"
 #include "version.hpp"
 #include "xyz/openbmc_project/Collection/DeleteAll/server.hpp"
 
@@ -10,6 +11,7 @@
 #include <xyz/openbmc_project/Association/Definitions/server.hpp>
 #include <xyz/openbmc_project/Common/FactoryReset/server.hpp>
 #include <xyz/openbmc_project/Control/FieldMode/server.hpp>
+#include <xyz/openbmc_project/Software/MinimumVersion/server.hpp>
 
 #include <string>
 #include <vector>
@@ -30,12 +32,32 @@ using ItemUpdaterInherit = sdbusplus::server::object_t<
     sdbusplus::xyz::openbmc_project::Control::server::FieldMode,
     sdbusplus::xyz::openbmc_project::Association::server::Definitions,
     sdbusplus::xyz::openbmc_project::Collection::server::DeleteAll>;
+using MinimumVersionInherit = sdbusplus::server::object_t<
+    sdbusplus::xyz::openbmc_project::Software::server::MinimumVersion>;
 
 namespace MatchRules = sdbusplus::bus::match::rules;
 using VersionClass = phosphor::software::manager::Version;
 using LidClass = phosphor::software::manager::Lid;
 using AssociationList =
     std::vector<std::tuple<std::string, std::string, std::string>>;
+
+/** @class MinimumVersion
+ *  @brief OpenBMC MinimumVersion implementation.
+ *  @details A concrete implementation for
+ *  xyz.openbmc_project.Software.MinimumVersion DBus API.
+ */
+class MinimumVersion : public MinimumVersionInherit
+{
+  public:
+    /** @brief Constructs MinimumVersion
+     *
+     * @param[in] bus - The D-Bus bus object
+     * @param[in] path - The D-bus object path
+     */
+    MinimumVersion(sdbusplus::bus_t& bus, const std::string& path) :
+        MinimumVersionInherit(bus, path.c_str(), action::emit_interface_added)
+    {}
+};
 
 /** @class ItemUpdater
  *  @brief Manages the activation of the BMC version items.
@@ -79,8 +101,17 @@ class ItemUpdater : public ItemUpdaterInherit
 #ifdef HOST_BIOS_UPGRADE
         createBIOSObject();
 #endif
+
+        if (minimum_ship_level::enabled())
+        {
+            minimumVersionObject = std::make_unique<MinimumVersion>(bus, path);
+            minimumVersionObject->minimumVersion(
+                minimum_ship_level::getMinimumVersion());
+        }
+
         lidClass = std::make_unique<phosphor::software::manager::Lid>(
             bus, path.c_str());
+
         emit_object_added();
     };
 
@@ -283,6 +314,9 @@ class ItemUpdater : public ItemUpdaterInherit
      */
     bool checkImage(const std::string& filePath,
                     const std::vector<std::string>& imageList);
+
+    /** @brief Persistent MinimumVersion D-Bus object */
+    std::unique_ptr<MinimumVersion> minimumVersionObject;
 
 #ifdef HOST_BIOS_UPGRADE
     /** @brief Create the BIOS object without knowing the version.

--- a/msl_verify.cpp
+++ b/msl_verify.cpp
@@ -64,20 +64,12 @@ void minimum_ship_level::parse(const std::string& inpVersion,
 
 bool minimum_ship_level::verify(const std::string& versionManifest)
 {
-    auto isUninitialized = [](std::string mslStr) {
-        return (mslStr.empty() || (mslStr.front() == '\0') ||
-                isspace(mslStr.front()) || (mslStr.front() == '0'));
-    };
-
-    //  If there is no msl or mslRegex return upgrade is needed.
-    std::string msl{BMC_MSL};
-    std::string mslRegex{REGEX_BMC_MSL};
-
     // The MSL value was requested to be reset.
     if (std::filesystem::exists(resetFile))
     {
         // Predefined reset msl version string
         std::string resetStr{"fw1020.00-00"};
+        std::string mslRegex{REGEX_BMC_MSL};
         if (!mslRegex.empty())
         {
             std::smatch match;
@@ -91,12 +83,8 @@ bool minimum_ship_level::verify(const std::string& versionManifest)
         writeSystemKeyword(resetStr);
     }
 
-    if (msl.empty())
-    {
-        //  If the minimum level was not set as a compile-time option, check VPD
-        msl = readSystemKeyword();
-    }
-    if ((isUninitialized(msl)) || mslRegex.empty())
+    //  If there is no msl or mslRegex return upgrade is needed.
+    if (!enabled())
     {
         return true;
     }
@@ -104,6 +92,7 @@ bool minimum_ship_level::verify(const std::string& versionManifest)
     // Define mslVersion variable and populate in Version format
     // {major,minor,rev} using parse function.
 
+    std::string msl = getMinimumVersion();
     Version mslVersion = {0, 0, 0};
     parse(msl, mslVersion);
 
@@ -232,4 +221,31 @@ void minimum_ship_level::set()
 void minimum_ship_level::reset()
 {
     std::ofstream outputFile(resetFile);
+}
+
+bool minimum_ship_level::enabled()
+{
+    auto isUninitialized = [](std::string mslStr) {
+        return (mslStr.empty() || (mslStr.front() == '\0') ||
+                isspace(mslStr.front()) || (mslStr.front() == '0'));
+    };
+
+    std::string msl = getMinimumVersion();
+    std::string mslRegex{REGEX_BMC_MSL};
+    if (!(isUninitialized(msl)) && !mslRegex.empty())
+    {
+        return true;
+    }
+    return false;
+}
+
+std::string minimum_ship_level::getMinimumVersion()
+{
+    std::string msl{BMC_MSL};
+    if (msl.empty())
+    {
+        //  If the minimum level was not set as a compile-time option, check VPD
+        msl = readSystemKeyword();
+    }
+    return msl;
 }

--- a/msl_verify.hpp
+++ b/msl_verify.hpp
@@ -58,4 +58,14 @@ void set();
  */
 void reset();
 
+/** @brief Check if the minimum ship level option is enabled
+ *  @return true if enabled, false otherwise
+ */
+bool enabled();
+
+/** @brief Get the minimum version
+ *  @return[out] msl - Minimum version string
+ */
+std::string getMinimumVersion();
+
 } // namespace minimum_ship_level


### PR DESCRIPTION
The Minimum Version is now an available D-Bus interface:
```
https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/70110
```
Populate its value if it's being defined.

Tested: If the msl meson options are defined, the D-Bus property is populated with the value of the defined minimum version:
```
root@witherspoon:~# busctl get-property xyz.openbmc_project.Software.BMC.Updater /xyz/openbmc_project/software xyz.openbmc_project.Software.MinimumVersion MinimumVersion
s "2.15.0"
```

Change-Id: I0f9df0cfd7c06794df836e161b3416094a8535de