### PR TITLE
1110: Move the MinimumVersion property to the id path

### DIFF
--- a/item_updater.cpp
+++ b/item_updater.cpp
@@ -275,11 +275,19 @@ void ItemUpdater::processBMCImage()
 
             auto path = fs::path(SOFTWARE_OBJPATH) / id;
 
-            // Create functional association if this is the functional
-            // version
+            // Create functional association and minimum ship level instance if
+            // this is the functional version
             if (functional)
             {
                 createFunctionalAssociation(path);
+
+                if (minimum_ship_level::enabled())
+                {
+                    minimumVersionObject =
+                        std::make_unique<MinimumVersion>(bus, path);
+                    minimumVersionObject->minimumVersion(
+                        minimum_ship_level::getMinimumVersion());
+                }
             }
 
             AssociationList associations = {};

--- a/item_updater.hpp
+++ b/item_updater.hpp
@@ -101,17 +101,6 @@ class ItemUpdater : public ItemUpdaterInherit
 #ifdef HOST_BIOS_UPGRADE
         createBIOSObject();
 #endif
-
-        if (minimum_ship_level::enabled())
-        {
-            minimumVersionObject = std::make_unique<MinimumVersion>(bus, path);
-            minimumVersionObject->minimumVersion(
-                minimum_ship_level::getMinimumVersion());
-        }
-
-        lidClass = std::make_unique<phosphor::software::manager::Lid>(
-            bus, path.c_str());
-
         emit_object_added();
     };
 


### PR DESCRIPTION
Per feedback from the bmcweb maintainers, move the recently added MinimumVersion property to the software/<functional-id>/ path since it's tied to the BMC version.

Tested:
root@witherspoon:~# busctl
    get-property xyz.openbmc_project.Software.BMC.Updater
    /xyz/openbmc_project/software/26cddfb1
    xyz.openbmc_project.Software.MinimumVersion MinimumVersion
s "2.15.0"

Change-Id: I6c84d90282f4d58d0f776e9482d867208bbfe077