### PR TITLE
item_updater: Restore the LID interface

### DIFF
--- a/item_updater.hpp
+++ b/item_updater.hpp
@@ -101,6 +101,8 @@ class ItemUpdater : public ItemUpdaterInherit
 #ifdef HOST_BIOS_UPGRADE
         createBIOSObject();
 #endif
+        lidClass = std::make_unique<phosphor::software::manager::Lid>(
+            bus, path.c_str());
         emit_object_added();
     };
 


### PR DESCRIPTION
The LID interface was mistakenly removed when the minimum ship level functionality was rebased with upstream.

Change-Id: I4a7fb515e93a1672740e677d7d88b486acdab7d9