### PR TITLE
1110: msl: Add sync method

### DIFF
--- a/item_updater.cpp
+++ b/item_updater.cpp
@@ -283,6 +283,7 @@ void ItemUpdater::processBMCImage()
 
                 if (minimum_ship_level::enabled())
                 {
+                    minimum_ship_level::sync();
                     minimumVersionObject =
                         std::make_unique<MinimumVersion>(bus, path);
                     minimumVersionObject->minimumVersion(

--- a/msl_verify.hpp
+++ b/msl_verify.hpp
@@ -7,6 +7,7 @@ namespace minimum_ship_level
 {
 
 constexpr auto resetFile = "/tmp/reset-msl";
+constexpr auto mslFile = "msl-data";
 
 /** @brief Version components */
 struct Version
@@ -68,5 +69,17 @@ bool enabled();
  *  @return[out] msl - Minimum version string
  */
 std::string getMinimumVersion();
+
+/** @brief Syncs the msl value in VPD and flash
+ *  @details Sync the value in VPD to flash. If the VPD is blank, use the value
+ *           in flash to write the VPD.
+ */
+void sync();
+
+/** @brief Read the Min Ship Level from flash */
+std::string readFlashValue();
+
+/** @brief Write the Min Ship Level to flash */
+void writeFlashValue(const std::string& value);
 
 } // namespace minimum_ship_level


### PR DESCRIPTION
Upon start, the software updater service reads the Minimum Ship Level from the com.ibm.ipzvpd.VSYS FV property on the bmc card and from flash memory in /var/lib/phosphor-bmc-code-mgmt/msl-data. Then it syncs them up with one another, prioritizing first the bmc card, then flash memory.

The sync mechanism is needed to keep a backup of the value in order to restore it if the planar or BMC card are replaced.

Tested: Verified the syncing is done upon reboot. Verified no syncing is done when the value is all spaces (default), and when the VPD service is not running.

Change-Id: I996f373711ac958a98e01fd65b09203016cbd69b