### PR TITLE
1060: lid: validate: Fix parsing logic

### DIFF
--- a/lid.hpp
+++ b/lid.hpp
@@ -48,7 +48,6 @@ class Lid : public LidInherit
     void assembleCodeUpdateImage();
 
   private:
-    std::string fwVersion;
     bool isOneOff = false;
 
     sdbusplus::bus_t& bus;

--- a/uak_verify.cpp
+++ b/uak_verify.cpp
@@ -130,7 +130,6 @@ bool UpdateAccessKey::checkIfUAKValid(const std::string& buildID)
 bool UpdateAccessKey::verify(const std::string& gaDate,
                              const std::string& version, bool isOneOff)
 {
-    std::string expirationDate{};
     std::string buildID{};
     buildID = gaDate;
 
@@ -140,6 +139,13 @@ bool UpdateAccessKey::verify(const std::string& gaDate,
         {
             if (version.empty())
             {
+                error(
+                    "Update Access Key validation failed. Expiration Date: {EXP_DATE}. "
+                    "Build date: {BUILD_ID}.",
+                    "EXP_DATE", expirationDate, "BUILD_ID", buildIDTrunc);
+                elog<AccessKeyErr>(
+                    ExpiredAccessKey::EXP_DATE(expirationDate.c_str()),
+                    ExpiredAccessKey::BUILD_ID(buildIDTrunc.c_str()));
                 return false;
             }
             std::string versionID =


### PR DESCRIPTION
Parse all the marker lid fields first before doing the verifications because the uak check relies on the SPNM field, which currently is placed after the FIPP field, causing the UAK check to have an empty version string.

If the version string was empty, the UAK check was not logging an error. Need to log an error to tell PHYP that the update has failed. Although an empty version string should not be seen again unless there's an error in the marker lid.

For the msl, read version string before appending null terminator. Need to add the null terminator after reading the string, otherwise the read operation will overwrite the null terminator.

Change-Id: Icb84873836e1a44cafc489b45b39d90701e84e32