### PR TITLE
msl: Increase the size of the major release

### DIFF
--- a/msl_verify.hpp
+++ b/msl_verify.hpp
@@ -12,7 +12,7 @@ constexpr auto mslFile = "msl-data";
 /** @brief Version components */
 struct Version
 {
-    uint8_t major;
+    uint16_t major;
     uint8_t minor;
     uint8_t rev;
 };


### PR DESCRIPTION
Increase the size of the major release variable so that it can hold values that are bigger than 255, such as 1060, so that comparisons against different Power generations can be done, such as against 1110.

Change-Id: Icd61bbe457de6f3c8a71a4bb555f6efbab3508b0