### PR TITLE
1110: mmc: Create a log when factory reset is requested

### DIFF
--- a/mmc/item_updater_helper.cpp
+++ b/mmc/item_updater_helper.cpp
@@ -4,6 +4,9 @@
 
 #include "utils.hpp"
 
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/exception.hpp>
+
 #include <thread>
 
 namespace phosphor
@@ -12,6 +15,8 @@ namespace software
 {
 namespace updater
 {
+
+PHOSPHOR_LOG2_USING;
 
 void Helper::setEntry(const std::string& /* entryId */, uint8_t /* value */)
 {
@@ -30,8 +35,33 @@ void Helper::cleanup()
 
 void Helper::factoryReset()
 {
+    // Create informational log
+    constexpr auto logObjPath = "/xyz/openbmc_project/logging";
+    constexpr auto logInterface = "xyz.openbmc_project.Logging.Create";
+    constexpr auto logSeverity =
+        "xyz.openbmc_project.Logging.Entry.Level.Informational";
+    constexpr auto logMessage =
+        "xyz.openbmc_project.Software.Version.Info.FactoryResetRequested";
+    try
+    {
+        auto service = utils::getService(bus, logObjPath, logInterface);
+        auto method = bus.new_method_call(service.c_str(), logObjPath,
+                                          logInterface, "Create");
+        std::map<std::string, std::string> data{};
+        method.append(logMessage, logSeverity, data);
+        bus.call_noreply(method);
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        error("Error creating log: {ERROR}", "ERROR", e);
+    }
+
     // Mark the read-write partition for recreation upon reboot.
     utils::execute("/sbin/fw_setenv", "rwreset", "true");
+
+    // Wait a few seconds for the log to be reported
+    constexpr auto logWait = std::chrono::seconds(3);
+    std::this_thread::sleep_for(logWait);
 }
 
 void Helper::removeVersion(const std::string& flashId)


### PR DESCRIPTION
For debug, it has been requested to create an informational error log (PEL) that calls home when a factory reset is requested. This log will need to be offloaded by the HMC prior to the BMC reboot.

The HMC takes less than a second to detect a new log, offload it, and ack it. Therefore sleep for 3s to allow enough time for this process to happen. The processing thread in the HMC may be busy if there are other events being created, but from testing with multiple logs created, the HMC handles them still within a second.

It is not critical to ensure that this log is offloaded by the HMC on all cases. Therefore it is not worth the effort on trying to determine if the system is HMC-managed and track that the HMC has ack'd the log.

Change-Id: Id43b0d238193f095bf2666b54966d8ed2710bcb7