### PR TITLE
1110: tar: Specify -C parameter before target directory

### DIFF
--- a/gen-lids-image-tar
+++ b/gen-lids-image-tar
@@ -40,8 +40,8 @@ cp $HOSTFW_IMAGE_PATH $UPDATE_DIR_PATH/$HOSTFW_IMAGE_NAME
 #Remove the tarball file, then re-generate it with so that the hostfw image becomes part of the tarball
 rm -fr $TAR_IMAGE_PATH
 
-echo "Executing tar -cf $TAR_IMAGE_PATH . -C $UPDATE_DIR_PATH"
-tar -cf $TAR_IMAGE_PATH . -C $UPDATE_DIR_PATH
+echo "Executing tar -C $UPDATE_DIR_PATH -cf $TAR_IMAGE_PATH ."
+tar -C $UPDATE_DIR_PATH -cf $TAR_IMAGE_PATH .
 
 #Create a temporary file to indicate that the update is am inband code update, this is required during activation
 #as the UAK verification is already done.


### PR DESCRIPTION
The -C parameter is order-sensitive, and therefore should be placed before the target directory that is to be used for creating an archive.

Tested: Verified tar was successful and inband code update finished without errors.

Change-Id: Ia001419d58810a6439ccdd674fbd162cc7aa79eb