### PR TITLE
1050: tar: Specify -C parameter before target directory

### DIFF
--- a/gen-bios-tar
+++ b/gen-bios-tar
@@ -58,66 +58,66 @@ machine=""
 version=""
 
 while [[ $# -gt 0 ]]; do
-  key="$1"
-  case $key in
-    -o|--out)
-      outfile="$2"
-      shift 2
-      ;;
-    -s|--sign)
-      do_sign=true
-      if [[ -n "${2}"  && "${2}" != -* ]]; then
-        private_key_path="$2"
-        shift 2
-      else
-        shift 1
-      fi
-      ;;
-    -m|--machine)
-      machine="$2"
-      shift 2
-      ;;
-    -v|--version)
-      version="$2"
-      shift 2
-      ;;
-    -e|--extended)
-      extended="$2"
-      shift 2
-      ;;
-    -h|--help)
-      echo "$help"
-      exit
-      ;;
-    -*)
-      echo "Unrecognised option $1"
-      echo "$help"
-      exit
-      ;;
-    *)
-      file="$1"
-      shift 1
-      ;;
-  esac
+    key="$1"
+    case $key in
+        -o|--out)
+            outfile="$2"
+            shift 2
+            ;;
+        -s|--sign)
+            do_sign=true
+            if [[ -n "${2}"  && "${2}" != -* ]]; then
+                private_key_path="$2"
+                shift 2
+            else
+                shift 1
+            fi
+            ;;
+        -m|--machine)
+            machine="$2"
+            shift 2
+            ;;
+        -v|--version)
+            version="$2"
+            shift 2
+            ;;
+        -e|--extended)
+            extended="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "$help"
+            exit
+            ;;
+        -*)
+            echo "Unrecognised option $1"
+            echo "$help"
+            exit
+            ;;
+        *)
+            file="$1"
+            shift 1
+            ;;
+    esac
 done
 
 if [ ! -f "${file}" ]; then
-  echo "${file} not found, Please enter a valid Bios image file"
-  echo "$help"
-  exit 1
+    echo "${file} not found, Please enter a valid Bios image file"
+    echo "$help"
+    exit 1
 fi
 
 if [[ -z $version ]]; then
-  echo "Please provide version of image with -v option"
-  exit 1
+    echo "Please provide version of image with -v option"
+    exit 1
 fi
 
 if [[ -z $outfile ]]; then
-  outfile=$(pwd)/obmc-bios.tar.gz
+    outfile=$(pwd)/obmc-bios.tar.gz
 else
-  if [[ $outfile != /* ]]; then
-    outfile=$(pwd)/$outfile
-  fi
+    if [[ $outfile != /* ]]; then
+        outfile=$(pwd)/$outfile
+    fi
 fi
 
 scratch_dir=$(mktemp -d)
@@ -127,22 +127,22 @@ scratch_dir=$(mktemp -d)
 trap '{ rm -r --interactive=never ${scratch_dir}; }' EXIT
 
 if [[ "${do_sign}" == true ]]; then
-  if [[ -z "${private_key_path}" ]]; then
-    private_key_path=${scratch_dir}/OpenBMC.priv
-    echo "${private_key}" > "${private_key_path}"
-    echo "Image is NOT secure!! Signing with the open private key!"
-  else
-    if [[ ! -f "${private_key_path}" ]]; then
-      echo "Couldn't find private key ${private_key_path}."
-      exit 1
+    if [[ -z "${private_key_path}" ]]; then
+        private_key_path=${scratch_dir}/OpenBMC.priv
+        echo "${private_key}" > "${private_key_path}"
+        echo "Image is NOT secure!! Signing with the open private key!"
+    else
+        if [[ ! -f "${private_key_path}" ]]; then
+            echo "Couldn't find private key ${private_key_path}."
+            exit 1
+        fi
+
+        echo "Signing with ${private_key_path}."
     fi
 
-    echo "Signing with ${private_key_path}."
-  fi
-
-  public_key_file=publickey
-  public_key_path=${scratch_dir}/$public_key_file
-  openssl pkey -in "${private_key_path}" -pubout -out "${public_key_path}"
+    public_key_file=publickey
+    public_key_path=${scratch_dir}/$public_key_file
+    openssl pkey -in "${private_key_path}" -pubout -out "${public_key_path}"
 fi
 
 manifest_location="MANIFEST"
@@ -166,16 +166,16 @@ if [[ -n "${machine}" ]]; then
 fi
 
 if [[ "${do_sign}" == true ]]; then
-  private_key_name=$(basename "${private_key_path}")
-  key_type="${private_key_name%.*}"
-  echo KeyType="${key_type}" >> $manifest_location
-  echo HashType="RSA-SHA256" >> $manifest_location
+    private_key_name=$(basename "${private_key_path}")
+    key_type="${private_key_name%.*}"
+    echo KeyType="${key_type}" >> $manifest_location
+    echo HashType="RSA-SHA256" >> $manifest_location
 
-  for file in $files_to_sign; do
-    openssl dgst -sha256 -sign "${private_key_path}" -out "${file}.sig" "$file"
-  done
+    for file in $files_to_sign; do
+        openssl dgst -sha256 -sign "${private_key_path}" -out "${file}.sig" "$file"
+    done
 
-  additional_files="*.sig"
+    additional_files="*.sig"
 fi
 
 # shellcheck disable=SC2086

--- a/gen-lids-image-tar
+++ b/gen-lids-image-tar
@@ -40,8 +40,8 @@ cp $HOSTFW_IMAGE_PATH $UPDATE_DIR_PATH/$HOSTFW_IMAGE_NAME
 #Remove the tarball file, then re-generate it with so that the hostfw image becomes part of the tarball
 rm -fr $TAR_IMAGE_PATH
 
-echo "Executing tar -cf $TAR_IMAGE_PATH . -C $UPDATE_DIR_PATH"
-tar -cf $TAR_IMAGE_PATH . -C $UPDATE_DIR_PATH
+echo "Executing tar -C $UPDATE_DIR_PATH -cf $TAR_IMAGE_PATH ."
+tar -C $UPDATE_DIR_PATH -cf $TAR_IMAGE_PATH .
 
 #Create a temporary file to indicate that the update is am inband code update, this is required during activation
 #as the UAK verification is already done.


### PR DESCRIPTION
The -C parameter is order-sensitive, and therefore should be placed before the target directory that is to be used for creating an archive.

Tested: Verified tar was successful and inband code update finished without errors.

Change-Id: Ia001419d58810a6439ccdd674fbd162cc7aa79eb