### PR TITLE
Clear staging dir in in-band code update flow

### DIFF
--- a/gen-lids-image-tar
+++ b/gen-lids-image-tar
@@ -21,6 +21,9 @@ UPDATE_IMAGE_PATH="/tmp/images/$TAR_IMAGE_NAME"
 #The path to the code update tarball file
 TAR_IMAGE_PATH=$IMAGE_DIR_PATH/$TAR_IMAGE_NAME
 
+#cleanup
+trap '{ echo "Remove Directories"; rm -fr $UPDATE_DIR_PATH; rm -fr $LID_DIR_PATH; rm -fr $IMAGE_DIR_PATH; }' EXIT SIGINT SIGTERM ERR
+
 #Create the hostfw squashfs image from the LID files without header
 
 echo Create the hostfw squashfs image from the LID files without header
@@ -49,9 +52,4 @@ touch /tmp/inband-update
 
 #Copy the tarball to the update directory to trigger the phosphor software manager to create a version interface
 cp $TAR_IMAGE_PATH $UPDATE_IMAGE_PATH
-
-#cleanup
-rm -fr UPDATE_DIR_PATH
-rm -fr LID_DIR_PATH
-rm -fr IMAGE_DIR_PATH
 


### PR DESCRIPTION
If the staging directory is not cleaned up, a second update attempts to repackage the same LID files and eventually fails with a signature error.

Multiple consecutive code updates is an IBM i–specific use case. To support this scenario, remove the staging directory immediately after assembling the LID files.

Fixes: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=757992