### PR TITLE
ufs: Enable UFS firmware update support from upstream

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -104,6 +104,7 @@ conf.set_quoted('SYNC_LIST_DIR_PATH', get_option('sync-list-dir-path'))
 conf.set_quoted('SYNC_LIST_FILE_NAME', get_option('sync-list-file-name'))
 conf.set_quoted('BMC_MSL', get_option('bmc-msl'))
 conf.set_quoted('REGEX_BMC_MSL', get_option('regex-bmc-msl'))
+conf.set_quoted('STORAGE_MODE', get_option('mmc-storage-mode'))
 
 if get_option('host-bios-upgrade').allowed()
     conf.set_quoted('BIOS_OBJPATH', get_option('bios-object-path'))

--- a/meson.options
+++ b/meson.options
@@ -11,6 +11,14 @@ option(
     description: 'The BMC layout type.',
 )
 
+option(
+    'mmc-storage-mode',
+    type: 'combo',
+    choices: ['mmc', 'ufs'],
+    value: 'mmc',
+    description: 'The BMC mass storage type.',
+)
+
 # Features
 option(
     'host-bios-upgrade',

--- a/mmc/obmc-flash-mmc-mirroruboot.service.in
+++ b/mmc/obmc-flash-mmc-mirroruboot.service.in
@@ -4,4 +4,5 @@ Description=Copy uboot from the currently booted bmc chip to the alternate chip
 [Service]
 Type=oneshot
 RemainAfterExit=no
+Environment=MODE=@STORAGE_MODE@
 ExecStart=/usr/bin/obmc-flash-bmc mmc-mirroruboot

--- a/mmc/obmc-flash-mmc@.service.in
+++ b/mmc/obmc-flash-mmc@.service.in
@@ -4,4 +4,5 @@ Description=Write image %I to BMC storage
 [Service]
 Type=oneshot
 RemainAfterExit=no
+Environment=MODE=@STORAGE_MODE@
 ExecStart=/usr/bin/obmc-flash-bmc mmc %i @IMG_UPLOAD_DIR@

--- a/obmc-flash-bmc
+++ b/obmc-flash-bmc
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
+# If the mode is not specified, default to mmc
+if [ -z "$MODE" ]; then
+    MODE="mmc"
+fi
+
 # Get the root mtd device number (mtdX) from "/dev/ubiblockX_Y on /"
 function findrootmtd() {
     rootmatch=" on / "
@@ -571,29 +576,40 @@ function mmc_mount() {
 
 function mmc_update() {
     # Update u-boot if needed
-    bootPartition="mmcblk0boot0"
+    if [ "$MODE" == "ufs" ]; then
+        bootPartition=$(basename "$(readlink -f /dev/disk/by-path/*ufshc-scsi-0:0:0:1)")
+    else
+        bootPartition=$(basename "$(readlink -f /dev/disk/by-path/*sdhci-boot0)")
+    fi
+    echo "mmc_update storage mode: $MODE bootPartition: $bootPartition"
     devUBoot="/dev/${bootPartition}"
     imgUBoot="${imgpath}/${version}/image-u-boot"
     if [ "$(cmp_uboot "${devUBoot}" "${imgUBoot}")" != "0" ]; then
-        echo 0 > "/sys/block/${bootPartition}/force_ro"
-        dd if="${imgUBoot}" of="${devUBoot}"
-        echo 1 > "/sys/block/${bootPartition}/force_ro"
+        if [ -e "/sys/block/${bootPartition}/force_ro" ]; then
+            echo 0 > "/sys/block/${bootPartition}/force_ro"
+            dd if="${imgUBoot}" of="${devUBoot}"
+            echo 1 > "/sys/block/${bootPartition}/force_ro"
+        else
+            dd if="${imgUBoot}" of="${devUBoot}"
+        fi
     fi
 
     # Update the secondary (non-running) boot and rofs partitions.
     label="$(mmc_get_secondary_label)"
 
+    diskPartition=$(basename "$(readlink -f /dev/disk/by-partlabel/boot-"${label}")")
+    diskdev=$(basename "$(dirname "$(realpath "/sys/class/block/${diskPartition}")")")
+    echo "mmc_update label: $label diskPartition: $diskPartition diskdev: $diskdev"
+
     # Update the boot and rootfs partitions, restore their labels after the update
     # by getting the partition number mmcblk0pX from their label.
     zstd -d -c "${imgpath}"/"${version}"/image-kernel | dd of="/dev/disk/by-partlabel/boot-${label}"
-    number="$(readlink -f /dev/disk/by-partlabel/boot-"${label}")"
-    number="${number##*mmcblk0p}"
-    sgdisk --change-name="${number}":boot-"${label}" /dev/mmcblk0 1>/dev/null
+    number="$(readlink -f /dev/disk/by-partlabel/boot-"${label}" | grep -o '[0-9]\+$')"
+    sgdisk --change-name="${number}":boot-"${label}" "/dev/${diskdev}" 1>/dev/null
 
     zstd -d -c "${imgpath}"/"${version}"/image-rofs | dd of="/dev/disk/by-partlabel/rofs-${label}"
-    number="$(readlink -f /dev/disk/by-partlabel/rofs-"${label}")"
-    number="${number##*mmcblk0p}"
-    sgdisk --change-name="${number}":rofs-"${label}" /dev/mmcblk0 1>/dev/null
+    number="$(readlink -f /dev/disk/by-partlabel/rofs-"${label}" | grep -o '[0-9]\+$')"
+    sgdisk --change-name="${number}":rofs-"${label}" "/dev/${diskdev}" 1>/dev/null
 
     # Run this after sgdisk for labels to take effect.
     partprobe
@@ -643,14 +659,22 @@ function mmc_setprimary() {
 }
 
 function mmc_mirroruboot() {
+    if [ "$MODE" == "ufs" ]; then
+        storage_boot0=$(basename "$(readlink -f /dev/disk/by-path/*ufshc-scsi-0:0:0:1)")
+        storage_boot1=$(basename "$(readlink -f /dev/disk/by-path/*ufshc-scsi-0:0:0:2)")
+    else
+        storage_boot0=$(basename "$(readlink -f /dev/disk/by-path/*sdhci-boot0)")
+        storage_boot1=$(basename "$(readlink -f /dev/disk/by-path/*sdhci-boot1)")
+    fi
+    echo "mmc_mirroruboot storage mode: $MODE storage_boot0: $storage_boot0 storage_boot1: $storage_boot1"
     # Get current boot device; 0-primary_bootdev device; 1 - alt_bootdev
     bootdev=$(cat /sys/kernel/debug/aspeed/sbc/abr_image)
     if [[ "${bootdev}" == "0" ]]; then
-        bootPartition="mmcblk0boot0"
-        alt_bootPartition="mmcblk0boot1"
+        bootPartition="${storage_boot0}"
+        alt_bootPartition="${storage_boot1}"
     else
-        bootPartition="mmcblk0boot1"
-        alt_bootPartition="mmcblk0boot0"
+        bootPartition="${storage_boot1}"
+        alt_bootPartition="${storage_boot0}"
     fi
 
     devUBoot="/dev/${bootPartition}"
@@ -663,9 +687,13 @@ function mmc_mirroruboot() {
 
     if [[ "${checksum_UBoot}" != "${checksum_alt_UBoot}" ]]; then
         echo "Mirroring U-boot to alt chip"
-        echo 0 > "/sys/block/${alt_bootPartition}/force_ro"
-        dd if="${devUBoot}" of="${alt_devUBoot}"
-        echo 1 > "/sys/block/${alt_bootPartition}/force_ro"
+        if [ -e "/sys/block/${bootPartition}/force_ro" ]; then
+            echo 0 > "/sys/block/${alt_bootPartition}/force_ro"
+            dd if="${devUBoot}" of="${alt_devUBoot}"
+            echo 1 > "/sys/block/${alt_bootPartition}/force_ro"
+        else
+            dd if="${devUBoot}" of="${alt_devUBoot}"
+        fi
     fi
 }
 


### PR DESCRIPTION
Pull in required changes from the upstream repository to support UFS code update functionality. This adds UFS enablement for the FW1210 platform.

Note:
This change has not yet been fully tested due to pending simulation environment support.