### PR TITLE
Post Quantum secured code update

### DIFF
--- a/image_verify.cpp
+++ b/image_verify.cpp
@@ -35,6 +35,7 @@ using InternalFailure =
 
 constexpr auto keyTypeTag = "KeyType";
 constexpr auto hashFunctionTag = "HashType";
+constexpr auto hashTagSuffix = "_Hash_Type";
 
 Signature::Signature(const fs::path& imageDirPath,
                      const fs::path& signedConfPath) :
@@ -50,6 +51,7 @@ Signature::Signature(const fs::path& imageDirPath,
     auto convertedPurpose =
         sdbusplus::message::convert_from_string<VersionPurpose>(purposeString);
     purpose = convertedPurpose.value_or(Version::VersionPurpose::Unknown);
+    pqAlgorithm = getPQAlgorithmFromManifest();
 }
 
 AvailableKeyTypes Signature::getAvailableKeyTypesFromSystem() const
@@ -96,6 +98,51 @@ inline KeyHashPathPair Signature::getKeyHashFileNames(const Key_t& key) const
     return std::make_pair(std::move(hashpath), std::move(keyPath));
 }
 
+std::optional<Signature::PQAlgorithm>
+    Signature::getPQAlgorithmFromManifest() const
+{
+    fs::path manifestFile(imageDirPath / MANIFEST_FILE_NAME);
+
+    std::ifstream efile(manifestFile);
+    if (!efile.good())
+    {
+        return std::nullopt;
+    }
+
+    std::string line;
+    while (std::getline(efile, line))
+    {
+        // Look for lines ending with "_Hash_Type"
+        auto delimPos = line.find('=');
+        if (delimPos == std::string::npos)
+        {
+            continue;
+        }
+
+        std::string key = line.substr(0, delimPos);
+        std::string value = line.substr(delimPos + 1);
+
+        if (key.find(hashTagSuffix) == std::string::npos)
+        {
+            continue;
+        }
+
+        auto commaPos = value.find(',');
+        if (commaPos == std::string::npos)
+        {
+            continue;
+        }
+
+        Signature::PQAlgorithm algo;
+        algo.hashType = value.substr(0, commaPos);
+        algo.name = value.substr(commaPos + 1);
+
+        return algo;
+    }
+
+    return std::nullopt;
+}
+
 bool Signature::verifyFullImage()
 {
     bool ret = true;
@@ -132,6 +179,34 @@ bool Signature::verifyFullImage()
 
     ret = verifyFile(pkeyFullFile, pkeyFullFileSig, publicKeyFile, hashType);
 
+    if (ret)
+    {
+        if (pqAlgorithm.has_value())
+        {
+            std::error_code ec2;
+            fs::path algoDir(imageDirPath / pqAlgorithm->name);
+
+            if (fs::exists(algoDir, ec2))
+            {
+                fs::path algoFullImageSig = algoDir / imageFullSig;
+                fs::path algoPublicKeyFile = algoDir / PUBLICKEY_FILE_NAME;
+
+                if (fs::exists(algoFullImageSig, ec2) &&
+                    fs::exists(tmpFullFile, ec2))
+                {
+                    ret = verifyFile(tmpFullFile, algoFullImageSig,
+                                     algoPublicKeyFile, pqAlgorithm->hashType);
+                    if (!ret)
+                    {
+                        error(
+                            "Full image signature validation failed for {ALGO}",
+                            "ALGO", pqAlgorithm->name);
+                    }
+                }
+            }
+        }
+    }
+
     std::error_code ec;
     fs::remove(tmpFullFile, ec);
 #endif
@@ -161,7 +236,7 @@ bool Signature::verify()
         // for images with partitions
         std::vector<std::string> imageUpdateList = {bmcFullImages};
         valid = checkAndVerifyImage(imageDirPath, publicKeyFile,
-                                    imageUpdateList, bmcFilesFound);
+                                    imageUpdateList, bmcFilesFound, hashType);
         if (bmcFilesFound && !valid)
         {
             return false;
@@ -172,11 +247,17 @@ bool Signature::verify()
             // Validate bmcImages
             imageUpdateList.clear();
             imageUpdateList.assign(bmcImages.begin(), bmcImages.end());
-            valid = checkAndVerifyImage(imageDirPath, publicKeyFile,
-                                        imageUpdateList, bmcFilesFound);
-            if (bmcFilesFound && !valid)
+            valid =
+                checkAndVerifyImage(imageDirPath, publicKeyFile,
+                                    imageUpdateList, bmcFilesFound, hashType);
+
+            if (bmcFilesFound && valid)
             {
-                return false;
+                if (!verifyPQSignatures(bmcImages))
+                {
+                    error("PQ image signature verification failed");
+                    return false;
+                }
             }
         }
 
@@ -206,6 +287,34 @@ bool Signature::verify()
                     error("Image file Signature Validation failed on {IMAGE}",
                           "IMAGE", optionalImage);
                     return false;
+                }
+
+                if (pqAlgorithm.has_value())
+                {
+                    fs::path algoDir(imageDirPath / pqAlgorithm->name);
+
+                    if (fs::exists(algoDir, ec))
+                    {
+                        fs::path algoPublicKeyFile =
+                            algoDir / PUBLICKEY_FILE_NAME;
+                        fs::path algoSigFile =
+                            algoDir / (optionalImage + ".sig");
+
+                        if (fs::exists(algoSigFile, ec))
+                        {
+                            bool algoValid =
+                                verifyFile(file, algoSigFile, algoPublicKeyFile,
+                                           pqAlgorithm->hashType);
+                            if (!algoValid)
+                            {
+                                error(
+                                    "Signature validation failed for optional image {IMAGE} with {ALGO}",
+                                    "IMAGE", optionalImage, "ALGO",
+                                    pqAlgorithm->name);
+                                return false;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -284,7 +393,58 @@ bool Signature::systemLevelVerify()
                                    hashFunc);
                 if (valid)
                 {
-                    break;
+                    if (pqAlgorithm.has_value())
+                    {
+                        std::error_code ec;
+                        fs::path algoDir(imageDirPath / pqAlgorithm->name);
+
+                        if (!fs::exists(algoDir, ec))
+                        {
+                            break; // RSA passed, PQ optional
+                        }
+
+                        // Check if system has corresponding key
+                        fs::path systemAlgoKeyPath =
+                            signedConfPath / keyType / pqAlgorithm->name /
+                            PUBLICKEY_FILE_NAME;
+
+                        if (!fs::exists(systemAlgoKeyPath, ec))
+                        {
+                            break; // RSA passed, PQ optional
+                        }
+
+                        fs::path algoManifestSig = algoDir / MANIFEST_FILE_NAME;
+                        algoManifestSig.replace_extension(SIGNATURE_FILE_EXT);
+
+                        fs::path algoPkeySig = algoDir / PUBLICKEY_FILE_NAME;
+                        algoPkeySig.replace_extension(SIGNATURE_FILE_EXT);
+
+                        valid = verifyFile(manifestFile, algoManifestSig,
+                                           systemAlgoKeyPath,
+                                           pqAlgorithm->hashType);
+                        if (!valid)
+                        {
+                            error("System level verification failed for {ALGO}",
+                                  "ALGO", pqAlgorithm->name);
+                            break;
+                        }
+
+                        valid =
+                            verifyFile(pkeyFile, algoPkeySig, systemAlgoKeyPath,
+                                       pqAlgorithm->hashType);
+                        if (!valid)
+                        {
+                            error(
+                                "System level publickey verification failed for {ALGO}",
+                                "ALGO", pqAlgorithm->name);
+                            break;
+                        }
+                    }
+
+                    if (valid)
+                    {
+                        break;
+                    }
                 }
             }
         }
@@ -312,16 +472,15 @@ bool Signature::verifyFile(const fs::path& file, const fs::path& sigFile,
         elog<InternalFailure>();
     }
 
-    // Create RSA.
-    auto publicRSA = createPublicRSA(publicKey);
-    if (!publicRSA)
+    auto publicKeyPtr = createPublicKey(publicKey);
+    if (!publicKeyPtr)
     {
-        error("Failed to create RSA from {PATH}", "PATH", publicKey);
+        error("Failed to create public key from {PATH}", "PATH", publicKey);
         elog<InternalFailure>();
     }
 
     // Initializes a digest context.
-    EVP_MD_CTX_Ptr rsaVerifyCtx(EVP_MD_CTX_new(), ::EVP_MD_CTX_free);
+    EVP_MD_CTX_Ptr verifyCtx(EVP_MD_CTX_new(), ::EVP_MD_CTX_free);
 
     // Adds all digest algorithms to the internal table
     OpenSSL_add_all_digests();
@@ -335,8 +494,8 @@ bool Signature::verifyFile(const fs::path& file, const fs::path& sigFile,
         elog<InternalFailure>();
     }
 
-    auto result = EVP_DigestVerifyInit(rsaVerifyCtx.get(), nullptr, hashStruct,
-                                       nullptr, publicRSA.get());
+    auto result = EVP_DigestVerifyInit(verifyCtx.get(), nullptr, hashStruct,
+                                       nullptr, publicKeyPtr.get());
 
     if (result <= 0)
     {
@@ -349,7 +508,7 @@ bool Signature::verifyFile(const fs::path& file, const fs::path& sigFile,
     auto size = fs::file_size(file, ec);
     auto dataPtr = mapFile(file, size);
 
-    result = EVP_DigestVerifyUpdate(rsaVerifyCtx.get(), dataPtr(), size);
+    result = EVP_DigestVerifyUpdate(verifyCtx.get(), dataPtr(), size);
     if (result <= 0)
     {
         error("Error ({RC}) occurred during EVP_DigestVerifyUpdate", "RC",
@@ -362,8 +521,7 @@ bool Signature::verifyFile(const fs::path& file, const fs::path& sigFile,
     auto signature = mapFile(sigFile, size);
 
     result = EVP_DigestVerifyFinal(
-        rsaVerifyCtx.get(), reinterpret_cast<unsigned char*>(signature()),
-        size);
+        verifyCtx.get(), reinterpret_cast<unsigned char*>(signature()), size);
 
     // Check the verification result.
     if (result < 0)
@@ -382,7 +540,7 @@ bool Signature::verifyFile(const fs::path& file, const fs::path& sigFile,
     return true;
 }
 
-inline EVP_PKEY_Ptr Signature::createPublicRSA(const fs::path& publicKey)
+inline EVP_PKEY_Ptr Signature::createPublicKey(const fs::path& publicKey)
 {
     std::error_code ec;
     auto size = fs::file_size(publicKey, ec);
@@ -411,7 +569,8 @@ CustomMap Signature::mapFile(const fs::path& path, size_t size)
 
 bool Signature::checkAndVerifyImage(
     const std::string& filePath, const std::string& publicKeyPath,
-    const std::vector<std::string>& imageList, bool& fileFound)
+    const std::vector<std::string>& imageList, bool& fileFound,
+    const std::string& hashType, const std::string& sigSubDir)
 {
     bool valid = true;
 
@@ -429,8 +588,19 @@ bool Signature::checkAndVerifyImage(
         }
         fileFound = true;
 
-        fs::path sigFile(file);
-        sigFile += SIGNATURE_FILE_EXT;
+        fs::path sigFile;
+        if (sigSubDir.empty())
+        {
+            // Top-level: signature in same directory
+            sigFile = file;
+            sigFile += SIGNATURE_FILE_EXT;
+        }
+        else
+        {
+            // Subdirectory: signature in algorithm-specific subdirectory
+            sigFile = fs::path(filePath) / sigSubDir /
+                      (bmcImage + SIGNATURE_FILE_EXT);
+        }
 
         // Verify the signature.
         valid = verifyFile(file, sigFile, publicKeyPath, hashType);
@@ -444,6 +614,36 @@ bool Signature::checkAndVerifyImage(
 
     return valid;
 }
+
+bool Signature::verifyPQSignatures(const std::vector<std::string>& imageList)
+{
+    if (!pqAlgorithm.has_value())
+    {
+        return true; // No PQ algorithm, skip
+    }
+
+    std::error_code ec;
+    fs::path algoDir(imageDirPath / pqAlgorithm->name);
+
+    if (!fs::exists(algoDir, ec))
+    {
+        return true; // PQ directory doesn't exist, optional
+    }
+
+    fs::path algoPublicKeyFile = algoDir / PUBLICKEY_FILE_NAME;
+    if (!fs::exists(algoPublicKeyFile, ec))
+    {
+        error("Public key not found in {ALGO} directory", "ALGO",
+              pqAlgorithm->name);
+        return false;
+    }
+
+    bool algoFileFound = false;
+    return checkAndVerifyImage(imageDirPath, algoPublicKeyFile.string(),
+                               imageList, algoFileFound, pqAlgorithm->hashType,
+                               pqAlgorithm->name);
+}
+
 } // namespace image
 } // namespace software
 } // namespace phosphor

--- a/image_verify.hpp
+++ b/image_verify.hpp
@@ -206,7 +206,7 @@ class Signature
      * @param[in]  - publickey
      * @param[out] - EVP_PKEY Object.
      */
-    static inline EVP_PKEY_Ptr createPublicKey(const fs::path& publicKey);
+    inline EVP_PKEY_Ptr createPublicKey(const fs::path& publicKey);
 
     /**
      * @brief Memory map the  file
@@ -253,7 +253,7 @@ class Signature
      * @return true if all image files are found in BMC tarball and
      * Verify Sucess false if one of image files is missing
      */
-    static bool checkAndVerifyImage(
+    bool checkAndVerifyImage(
         const std::string& filePath, const std::string& publicKeyPath,
         const std::vector<std::string>& imageList, bool& fileFound,
         const std::string& hashType = "", const std::string& sigSubDir = "");

--- a/image_verify.hpp
+++ b/image_verify.hpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include <filesystem>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -174,6 +175,21 @@ class Signature
     inline KeyHashPathPair getKeyHashFileNames(const Key_t& key) const;
 
     /**
+     * Structure to hold post-quantum algorithm information
+     */
+    struct PQAlgorithm
+    {
+        std::string name;     // Algorithm name
+        std::string hashType; // Hash function
+    };
+
+    /**
+     * @brief Get post-quantum algorithm from MANIFEST file
+     * @return Optional containing PQ algorithm, or nullopt if none found
+     */
+    std::optional<PQAlgorithm> getPQAlgorithmFromManifest() const;
+
+    /**
      * @brief Verify the file signature using public key and hash function
      *
      * @param[in]  - Image file path
@@ -186,11 +202,11 @@ class Signature
                     const fs::path& publicKey, const std::string& hashFunc);
 
     /**
-     * @brief Create RSA object from the public key
+     * @brief Create EVP_PKEY object from the public key
      * @param[in]  - publickey
-     * @param[out] - RSA Object.
+     * @param[out] - EVP_PKEY Object.
      */
-    inline EVP_PKEY_Ptr createPublicRSA(const fs::path& publicKey);
+    static inline EVP_PKEY_Ptr createPublicKey(const fs::path& publicKey);
 
     /**
      * @brief Memory map the  file
@@ -222,20 +238,34 @@ class Signature
     /** @brief The image purpose */
     VersionPurpose purpose;
 
+    /** @brief Cached post-quantum algorithm info from MANIFEST */
+    std::optional<PQAlgorithm> pqAlgorithm;
+
     /** @brief Check and Verify the required image files
      *
      * @param[in] filePath - BMC tarball file path
      * @param[in] publicKeyPath - publicKey file Path
      * @param[in] imageList - Image filenames included in the BMC tarball
      * @param[out] fileFound - Indicate if the file to verify is found or not
+     * @param[in] hashType - Hash function to use for verification
+     * @param[in] sigSubDir - Subdirectory containing signatures
      *
      * @return true if all image files are found in BMC tarball and
      * Verify Sucess false if one of image files is missing
      */
-    bool checkAndVerifyImage(const std::string& filePath,
-                             const std::string& publicKeyPath,
-                             const std::vector<std::string>& imageList,
-                             bool& fileFound);
+    static bool checkAndVerifyImage(
+        const std::string& filePath, const std::string& publicKeyPath,
+        const std::vector<std::string>& imageList, bool& fileFound,
+        const std::string& hashType = "", const std::string& sigSubDir = "");
+
+    /**
+     * @brief Verify post-quantum algorithm signatures for image files
+     *
+     * @param[in] imageList - List of image filenames to verify
+     * @return true if PQ verification succeeds or is not required, false on
+     * failure
+     */
+    bool verifyPQSignatures(const std::vector<std::string>& imageList);
 };
 
 } // namespace image

--- a/meson.build
+++ b/meson.build
@@ -1,13 +1,16 @@
-project('phosphor-bmc-code-mgmt', 'cpp',
+project(
+    'phosphor-bmc-code-mgmt',
+    'cpp',
     default_options: [
         'buildtype=debugoptimized',
         'cpp_std=c++23',
         'warning_level=3',
-        'werror=true'
+        'werror=true',
     ],
     meson_version: '>=1.1.1',
     license: 'Apache-2.0',
-    version: '1.0')
+    version: '1.0',
+)
 
 add_project_arguments(
     '-DBOOST_SYSTEM_NO_DEPRECATED',
@@ -25,7 +28,10 @@ cpp = meson.get_compiler('cpp')
 conf = configuration_data()
 
 # DBus information
-conf.set_quoted('BMC_INVENTORY_INTERFACE', 'xyz.openbmc_project.Inventory.Item.Bmc')
+conf.set_quoted(
+    'BMC_INVENTORY_INTERFACE',
+    'xyz.openbmc_project.Inventory.Item.Bmc',
+)
 conf.set_quoted('BUSNAME_UPDATER', 'xyz.openbmc_project.Software.BMC.Updater')
 conf.set_quoted('DOWNLOAD_BUSNAME', 'xyz.openbmc_project.Software.Download')
 conf.set_quoted('FILEPATH_IFACE', 'xyz.openbmc_project.Common.FilePath')
@@ -39,8 +45,14 @@ conf.set_quoted('SYSTEMD_PATH', '/org/freedesktop/systemd1')
 conf.set_quoted('SYSTEMD_INTERFACE', 'org.freedesktop.systemd1.Manager')
 conf.set_quoted('VERSION_BUSNAME', 'xyz.openbmc_project.Software.Version')
 conf.set_quoted('VERSION_IFACE', 'xyz.openbmc_project.Software.Version')
-conf.set_quoted('EXTENDED_VERSION_IFACE', 'xyz.openbmc_project.Software.ExtendedVersion')
-conf.set_quoted('COMPATIBLE_IFACE', 'xyz.openbmc_project.Inventory.Decorator.Compatible')
+conf.set_quoted(
+    'EXTENDED_VERSION_IFACE',
+    'xyz.openbmc_project.Software.ExtendedVersion',
+)
+conf.set_quoted(
+    'COMPATIBLE_IFACE',
+    'xyz.openbmc_project.Inventory.Decorator.Compatible',
+)
 
 # Names of the forward and reverse associations
 conf.set_quoted('ACTIVATION_FWD_ASSOCIATION', 'inventory')
@@ -68,7 +80,10 @@ conf.set('MMC_LAYOUT', get_option('bmc-layout').contains('mmc'))
 # Configurable features
 conf.set('HOST_BIOS_UPGRADE', get_option('host-bios-upgrade').allowed())
 conf.set('WANT_SIGNATURE_VERIFY', get_option('verify-signature').allowed())
-conf.set('WANT_ACCESS_KEY_VERIFY', get_option('verify-update-access-key').allowed())
+conf.set(
+    'WANT_ACCESS_KEY_VERIFY',
+    get_option('verify-update-access-key').allowed(),
+)
 
 # Configurable variables
 conf.set('ACTIVE_BMC_MAX_ALLOWED', get_option('active-bmc-max-allowed'))
@@ -95,11 +110,14 @@ if get_option('host-bios-upgrade').allowed()
 endif
 
 if get_option('bmc-static-dual-image').allowed()
-  conf.set('BMC_STATIC_DUAL_IMAGE', get_option('bmc-static-dual-image').allowed())
-  conf.set_quoted('ALT_ROFS_DIR', get_option('alt-rofs-dir'))
-  conf.set_quoted('ALT_RWFS', get_option('alt-rwfs-dir'))
+    conf.set(
+        'BMC_STATIC_DUAL_IMAGE',
+        get_option('bmc-static-dual-image').allowed(),
+    )
+    conf.set_quoted('ALT_ROFS_DIR', get_option('alt-rofs-dir'))
+    conf.set_quoted('ALT_RWFS', get_option('alt-rwfs-dir'))
 else
-  conf.set_quoted('ALT_RWFS', '/media/alt/var/persist')
+    conf.set_quoted('ALT_RWFS', '/media/alt/var/persist')
 endif
 
 configure_file(output: 'config.h', configuration: conf)
@@ -118,24 +136,23 @@ has_cereal = cpp.has_header_symbol(
     'cereal/cereal.hpp',
     'cereal::specialize',
     dependencies: cereal_dep,
-    required: false)
+    required: false,
+)
 if not has_cereal
     cereal_opts = import('cmake').subproject_options()
-    cereal_opts.add_cmake_defines({'BUILD_TESTS': 'OFF', 'SKIP_PERFORMANCE_COMPARISON': 'ON'})
+    cereal_opts.add_cmake_defines(
+        {'BUILD_TESTS': 'OFF', 'SKIP_PERFORMANCE_COMPARISON': 'ON'},
+    )
     cereal_proj = import('cmake').subproject(
         'cereal',
         options: cereal_opts,
-        required: false)
+        required: false,
+    )
     assert(cereal_proj.found(), 'cereal is required')
     cereal_dep = cereal_proj.dependency('cereal')
 endif
 
-deps = [
-    cereal_dep,
-    pdi_dep,
-    phosphor_logging_dep,
-    sdbusplus_dep,
-]
+deps = [cereal_dep, pdi_dep, phosphor_logging_dep, sdbusplus_dep]
 
 ssl = dependency('openssl')
 
@@ -158,7 +175,7 @@ unit_files = [
     'xyz.openbmc_project.Software.BMC.Updater.service.in',
     'xyz.openbmc_project.Software.Download.service.in',
     'xyz.openbmc_project.Software.Sync.service.in',
-    'xyz.openbmc_project.Software.Version.service.in'
+    'xyz.openbmc_project.Software.Version.service.in',
 ]
 
 if get_option('bmc-layout').contains('mmc')
@@ -167,27 +184,18 @@ else
     unit_files += 'xyz.openbmc_project.Software.Version.service.in'
 endif
 
-image_updater_sources = files(
-    'activation.cpp',
-    'images.cpp',
-    'item_updater.cpp',
-    'item_updater_main.cpp',
-    'serialize.cpp',
-    'version.cpp',
-    'utils.cpp',
-    'msl_verify.cpp',
-    'lid.cpp'
-)
+image_updater_sources = files('activation.cpp', 'images.cpp', 'item_updater.cpp', 'item_updater_main.cpp', 'lid.cpp'
+, 'msl_verify.cpp', 'serialize.cpp', 'utils.cpp', 'version.cpp')
 
 if get_option('bmc-layout').contains('static')
     image_updater_sources += files(
         'static/flash.cpp',
-        'static/item_updater_helper.cpp'
+        'static/item_updater_helper.cpp',
     )
 elif get_option('bmc-layout').contains('ubi')
     image_updater_sources += files(
         'ubi/flash.cpp',
-        'ubi/item_updater_helper.cpp'
+        'ubi/item_updater_helper.cpp',
     )
 
     unit_files += [
@@ -198,12 +206,12 @@ elif get_option('bmc-layout').contains('ubi')
         'ubi/obmc-flash-bmc-ubiro-remove@.service.in',
         'ubi/obmc-flash-bmc-ubirw.service.in',
         'ubi/obmc-flash-bmc-ubirw-remove.service.in',
-        'ubi/obmc-flash-bmc-updateubootvars@.service.in'
+        'ubi/obmc-flash-bmc-updateubootvars@.service.in',
     ]
 elif get_option('bmc-layout').contains('mmc')
     image_updater_sources += files(
         'mmc/flash.cpp',
-        'mmc/item_updater_helper.cpp'
+        'mmc/item_updater_helper.cpp',
     )
 
     unit_files += [
@@ -235,31 +243,25 @@ if get_option('sync-bmc-files').allowed()
         'sync_manager_main.cpp',
         'sync_watch.cpp',
         dependencies: deps,
-        install: true
+        install: true,
     )
 
-    install_data('synclist',
-        install_dir:  get_option('sysconfdir')
-    )
+    install_data('synclist', install_dir: get_option('sysconfdir'))
 
-    install_data('sync-once.sh',
+    install_data(
+        'sync-once.sh',
         install_mode: 'rwxr-xr-x',
-        install_dir: get_option('bindir')
+        install_dir: get_option('bindir'),
     )
 endif
 
 if (get_option('verify-signature').allowed())
-    image_updater_sources += files(
-        'utils.cpp',
-        'image_verify.cpp',
-        'openssl_alloc.cpp'
-    )
+    image_updater_sources += files('image_verify.cpp', 'openssl_alloc.cpp'
+    , 'utils.cpp')
 endif
 
 if (get_option('verify-update-access-key').allowed())
-    image_updater_sources += files(
-        'uak_verify.cpp'
-    )
+    image_updater_sources += files('uak_verify.cpp')
 endif
 
 executable(
@@ -267,14 +269,14 @@ executable(
     'download_manager.cpp',
     'download_manager_main.cpp',
     dependencies: deps,
-    install: true
+    install: true,
 )
 
 executable(
     'phosphor-image-updater',
     image_updater_sources,
     dependencies: [deps, ssl, boost_dep],
-    install: true
+    install: true,
 )
 
 software_manager_common_sources = files()
@@ -285,11 +287,9 @@ if get_option('software-update-dbus-interface').allowed()
         'software_manager.cpp',
         software_manager_common_sources,
         dependencies: [deps, ssl],
-        install: true
+        install: true,
     )
-    unit_files += [
-        'xyz.openbmc_project.Software.Manager.service.in'
-    ]
+    unit_files += ['xyz.openbmc_project.Software.Manager.service.in']
 endif
 
 executable(
@@ -300,7 +300,7 @@ executable(
     'watch.cpp',
     software_manager_common_sources,
     dependencies: [deps, ssl],
-    install: true
+    install: true,
 )
 
 executable(
@@ -310,32 +310,34 @@ executable(
     'utils.cpp',
     'version.cpp',
     dependencies: [CLI11, deps, ssl],
-    install: true
+    install: true,
 )
 
-install_data('obmc-flash-bmc',
+install_data(
+    'obmc-flash-bmc',
     install_mode: 'rwxr-xr-x',
-    install_dir: get_option('bindir')
+    install_dir: get_option('bindir'),
 )
 
-install_data('gen-lids-image-tar',
+install_data(
+    'gen-lids-image-tar',
     install_mode: 'rwxr-xr-x',
-    install_dir: get_option('bindir')
+    install_dir: get_option('bindir'),
 )
 
-install_data('detect-slot-aspeed',
+install_data(
+    'detect-slot-aspeed',
     install_mode: 'rwxr-xr-x',
-    install_dir: get_option('bindir')
+    install_dir: get_option('bindir'),
 )
 
-install_data('reset-cs0-aspeed',
+install_data(
+    'reset-cs0-aspeed',
     install_mode: 'rwxr-xr-x',
-    install_dir: get_option('bindir')
+    install_dir: get_option('bindir'),
 )
 
-install_data('software.conf',
-    install_dir: '/usr/lib/tmpfiles.d/'
-)
+install_data('software.conf', install_dir: '/usr/lib/tmpfiles.d/')
 
 foreach u : unit_files
     configure_file(
@@ -351,21 +353,24 @@ endforeach
 # need to define and build the tests from here
 build_tests = get_option('tests')
 if not build_tests.disabled()
-    gtest = dependency('gtest', main: true, disabler: true, required: build_tests)
-    include_srcs = declare_dependency(sources: [
-        'utils.cpp',
-        'image_verify.cpp',
-        'images.cpp',
-        'version.cpp']
+    gtest = dependency(
+        'gtest',
+        main: true,
+        disabler: true,
+        required: build_tests,
+    )
+    include_srcs = declare_dependency(
+        sources: ['utils.cpp', 'image_verify.cpp', 'images.cpp', 'version.cpp'],
     )
 
-    test('utest',
+    test(
+        'utest',
         executable(
             'utest',
             './test/utest.cpp',
-            dependencies: [deps, gtest, include_srcs, ssl]
-        )
-)
+            dependencies: [deps, gtest, include_srcs, ssl],
+        ),
+    )
 endif
 
 if get_option('usb-code-update').allowed()

--- a/meson.options
+++ b/meson.options
@@ -3,136 +3,182 @@
 # - static: NOR flash configured with fixed-sized MTD partitions.
 # - ubi: NOR flash device configured with UBI volumes.
 # - mmc: eMMC flash device configured with ext4 filesystems.
-option('bmc-layout', type: 'combo',
+option(
+    'bmc-layout',
+    type: 'combo',
     choices: ['static', 'ubi', 'mmc'],
     value: 'static',
-    description: 'The BMC layout type.')
+    description: 'The BMC layout type.',
+)
 
 # Features
-option('host-bios-upgrade', type: 'feature', value: 'enabled',
-    description: 'Enable host bios upgrade support.')
+option(
+    'host-bios-upgrade',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enable host bios upgrade support.',
+)
 
-option('sync-bmc-files', type: 'feature', value: 'enabled',
-    description: 'Enable sync of filesystem files.')
+option(
+    'sync-bmc-files',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enable sync of filesystem files.',
+)
 
 option('tests', type: 'feature', description: 'Build tests')
 
-option('verify-signature', type: 'feature', value: 'enabled',
-    description: 'Enable image signature validation.')
+option(
+    'verify-signature',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enable image signature validation.',
+)
 
 option(
-    'usb-code-update', type: 'feature', value: 'enabled',
+    'usb-code-update',
+    type: 'feature',
+    value: 'enabled',
     description: 'Firmware update via USB.',
 )
 
-option('software-update-dbus-interface', type: 'feature', value: 'enabled',
+option(
+    'software-update-dbus-interface',
+    type: 'feature',
+    value: 'enabled',
     description: 'Implementation using software update D-Bus interface - https://github.com/openbmc/docs/blob/master/designs/code-update.md.',
 )
 
 option(
-    'side-switch-on-boot', type: 'feature', value: 'enabled',
+    'side-switch-on-boot',
+    type: 'feature',
+    value: 'enabled',
     description: 'Automatic flash side switch on boot',
 )
 
-option('verify-update-access-key', type: 'feature', value: 'enabled',
-    description: 'Enabled access key validation.')
+option(
+    'verify-update-access-key',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enabled access key validation.',
+)
 
 # Variables
 option(
-    'active-bmc-max-allowed', type: 'integer',
+    'active-bmc-max-allowed',
+    type: 'integer',
     value: 1,
     description: 'The maximum allowed active BMC versions.',
 )
 
 option(
-    'hash-file-name', type: 'string',
+    'hash-file-name',
+    type: 'string',
     value: 'hashfunc',
     description: 'The name of the hash file.',
 )
 
 option(
-    'img-upload-dir', type: 'string',
+    'img-upload-dir',
+    type: 'string',
     value: '/tmp/images',
     description: 'Directory where downloaded software images are placed.',
 )
 
 option(
-    'manifest-file-name', type: 'string',
+    'manifest-file-name',
+    type: 'string',
     value: 'MANIFEST',
     description: 'The name of the MANIFEST file.',
 )
 
 option(
-    'media-dir', type: 'string',
+    'media-dir',
+    type: 'string',
     value: '/run/media',
     description: 'The base dir where all read-only partitions are mounted.',
 )
 
 option(
-    'optional-images', type: 'array',
+    'optional-images',
+    type: 'array',
     value: [],
     description: 'A list of additional image files in the BMC tarball.',
 )
 
 option(
-    'publickey-file-name', type: 'string',
+    'publickey-file-name',
+    type: 'string',
     value: 'publickey',
     description: 'The name of the public key file.',
 )
 
 option(
-    'signature-file-ext', type: 'string',
+    'signature-file-ext',
+    type: 'string',
     value: '.sig',
     description: 'The extension of the Signature file.',
 )
 
 option(
-    'signed-image-conf-path', type: 'string',
+    'signed-image-conf-path',
+    type: 'string',
     value: '/etc/activationdata/',
     description: 'Path of public key and hash function files.',
 )
 
 option(
-    'sync-list-dir-path', type: 'string',
+    'sync-list-dir-path',
+    type: 'string',
     value: '/etc/',
     description: 'The path to the sync list file directory.',
 )
 
 option(
-    'sync-list-file-name', type: 'string',
+    'sync-list-file-name',
+    type: 'string',
     value: 'synclist',
     description: 'The name of the sync list file.',
 )
 
 option(
-    'bmc-msl', type: 'string',
+    'bmc-msl',
+    type: 'string',
     value: '',
     description: 'The BMC minimum ship level.',
 )
 
 option(
-    'regex-bmc-msl', type: 'string',
+    'regex-bmc-msl',
+    type: 'string',
     value: '',
     description: 'The Regular expression to parse the MSL.',
 )
 
 option(
-    'bios-object-path', type: 'string',
+    'bios-object-path',
+    type: 'string',
     value: '/xyz/openbmc_project/software/bios_active',
     description: 'The BIOS DBus object path.',
 )
 
-option('bmc-static-dual-image', type: 'feature', value: 'enabled',
-    description: 'Enable the dual image support for static layout.')
+option(
+    'bmc-static-dual-image',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Enable the dual image support for static layout.',
+)
 
 option(
-    'alt-rofs-dir', type: 'string',
+    'alt-rofs-dir',
+    type: 'string',
     value: '/run/media/rofs-alt',
     description: 'The base dir where all read-only partitions are mounted.',
 )
 
 option(
-    'alt-rwfs-dir', type: 'string',
+    'alt-rwfs-dir',
+    type: 'string',
     value: '/run/media/rwfs-alt/cow',
     description: 'The dir for alt-rwfs partition.',
 )

--- a/side-switch/meson.build
+++ b/side-switch/meson.build
@@ -1,23 +1,20 @@
-source = [
-    'side_switch.cpp',
-    '../utils.cpp',
-    ]
+source = ['side_switch.cpp', '../utils.cpp']
 
 executable(
     'phosphor-bmc-side-switch',
     source,
     include_directories: ['..'],
-    dependencies: [
-        phosphor_logging_dep,
-    ],
+    dependencies: [phosphor_logging_dep],
     install: true,
-    install_dir: get_option('bindir')
+    install_dir: get_option('bindir'),
 )
 
 systemd_system_unit_dir = dependency('systemd').get_variable(
     'systemdsystemunitdir',
-    pkgconfig_define: ['prefix', get_option('prefix')])
+    pkgconfig_define: ['prefix', get_option('prefix')],
+)
 
 install_data(
-        'phosphor-bmc-side-switch.service',
-        install_dir: systemd_system_unit_dir)
+    'phosphor-bmc-side-switch.service',
+    install_dir: systemd_system_unit_dir,
+)

--- a/subprojects/packagefiles/boost/meson.build
+++ b/subprojects/packagefiles/boost/meson.build
@@ -1,11 +1,5 @@
-project('boost',
-    'cpp',
-    version : '1.84.0',
-    license : 'Boost'
-)
+project('boost', 'cpp', version: '1.84.0', license: 'Boost')
 
-boost_dep = declare_dependency(
-    include_directories : include_directories('.'),
-)
+boost_dep = declare_dependency(include_directories: include_directories('.'))
 
 meson.override_dependency('boost', boost_dep)

--- a/usb/meson.build
+++ b/usb/meson.build
@@ -6,11 +6,7 @@ endif
 
 sdeventplus_dep = dependency('sdeventplus')
 
-source = [
-    'usb_manager_main.cpp',
-    'usb_manager.cpp',
-    '../utils.cpp',
-    ]
+source = ['usb_manager_main.cpp', 'usb_manager.cpp', '../utils.cpp']
 
 executable(
     'phosphor-usb-code-update',
@@ -23,22 +19,21 @@ executable(
         sdeventplus_dep,
     ],
     install: true,
-    install_dir: get_option('bindir')
+    install_dir: get_option('bindir'),
 )
 
 systemd_system_unit_dir = dependency('systemd').get_variable(
     'systemdsystemunitdir',
-    pkgconfig_define: ['prefix', get_option('prefix')])
+    pkgconfig_define: ['prefix', get_option('prefix')],
+)
 udev_dir = dependency('udev').get_variable(
     'udev_dir',
-    pkgconfig_define: ['prefix', get_option('prefix')])
+    pkgconfig_define: ['prefix', get_option('prefix')],
+)
 
 install_data(
     'services/usb-code-update@.service',
-    install_dir: systemd_system_unit_dir
+    install_dir: systemd_system_unit_dir,
 )
 
-install_data(
-    '70-bmc-usb.rules',
-    install_dir: udev_dir / 'rules.d'
-)
+install_data('70-bmc-usb.rules', install_dir: udev_dir / 'rules.d')


### PR DESCRIPTION
Implement dual signature verification for BMC firmware updates by adding MLDSA (Module-Lattice-Based Digital Signature Algorithm) support alongside existing RSA signature verification. This provides quantum-resistant cryptographic protection for firmware integrity validation.

Design Overview:
- Hash-then-sign approach: Files are hashed with SHA3-512, then the hash is signed with MLDSA
- Two-level verification: System-level (MANIFEST/publickey) and image-level (firmware files)
- Backward compatible: MLDSA verification is optional; systems without MLDSA keys continue using RSA-only verification

tarball file structure

├── MANIFEST
├── MANIFEST.sig
├── publickey
├── publickey.sig
├── <Other files and its signatures>
└── MLDSA/
├── publickey
├── publickey.sig
├── MANIFEST.sig
├── <Other MLDSA signatures>

Tested:
Backward compatibility of the existing code update 
Verified the new signatures are verified when present.

Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-bmc-code-mgmt/+/87540

Change-Id: I2f82eae03d71a5b2bac48785c036a7888ba47a30