### PR TITLE
Enforce the MLDSA signature validation.

### DIFF
--- a/image_verify.cpp
+++ b/image_verify.cpp
@@ -52,6 +52,12 @@ Signature::Signature(const fs::path& imageDirPath,
         sdbusplus::message::convert_from_string<VersionPurpose>(purposeString);
     purpose = convertedPurpose.value_or(Version::VersionPurpose::Unknown);
     pqAlgorithm = getPQAlgorithmFromManifest();
+
+    if (!pqAlgorithm.has_value())
+    {
+        error("MANIFEST missing MLDSA");
+        elog<InternalFailure>();
+    }
 }
 
 AvailableKeyTypes Signature::getAvailableKeyTypesFromSystem() const
@@ -83,7 +89,10 @@ AvailableKeyTypes Signature::getAvailableKeyTypesFromSystem() const
             // extract the key types
             // /etc/activationdata/OpenBMC/  -> get OpenBMC from the path
             auto key = p.path().parent_path();
-            keyTypes.insert(key.filename());
+            if (key.parent_path() == signedConfPath)
+            {
+                keyTypes.insert(key.filename());
+            }
         }
     }
 
@@ -181,27 +190,28 @@ bool Signature::verifyFullImage()
 
     if (ret)
     {
-        if (pqAlgorithm.has_value())
+        std::error_code ec2;
+        fs::path algoDir(imageDirPath / pqAlgorithm->name);
+
+        if (!fs::exists(algoDir, ec2))
         {
-            std::error_code ec2;
-            fs::path algoDir(imageDirPath / pqAlgorithm->name);
+            error("MLDSA signatures missing");
+            return false;
+        }
+        else
+        {
+            fs::path algoFullImageSig = algoDir / imageFullSig;
+            fs::path algoPublicKeyFile = algoDir / PUBLICKEY_FILE_NAME;
 
-            if (fs::exists(algoDir, ec2))
+            if (fs::exists(algoFullImageSig, ec2) &&
+                fs::exists(tmpFullFile, ec2))
             {
-                fs::path algoFullImageSig = algoDir / imageFullSig;
-                fs::path algoPublicKeyFile = algoDir / PUBLICKEY_FILE_NAME;
-
-                if (fs::exists(algoFullImageSig, ec2) &&
-                    fs::exists(tmpFullFile, ec2))
+                ret = verifyFile(tmpFullFile, algoFullImageSig,
+                                 algoPublicKeyFile, pqAlgorithm->hashType);
+                if (!ret)
                 {
-                    ret = verifyFile(tmpFullFile, algoFullImageSig,
-                                     algoPublicKeyFile, pqAlgorithm->hashType);
-                    if (!ret)
-                    {
-                        error(
-                            "Full image signature validation failed for {ALGO}",
-                            "ALGO", pqAlgorithm->name);
-                    }
+                    error("Full image signature validation failed for {ALGO}",
+                          "ALGO", pqAlgorithm->name);
                 }
             }
         }
@@ -289,30 +299,30 @@ bool Signature::verify()
                     return false;
                 }
 
-                if (pqAlgorithm.has_value())
+                fs::path algoDir(imageDirPath / pqAlgorithm->name);
+
+                if (fs::exists(algoDir, ec))
                 {
-                    fs::path algoDir(imageDirPath / pqAlgorithm->name);
+                    fs::path algoPublicKeyFile = algoDir / PUBLICKEY_FILE_NAME;
+                    fs::path algoSigFile = algoDir / (optionalImage + ".sig");
 
-                    if (fs::exists(algoDir, ec))
+                    if (!fs::exists(algoSigFile, ec))
                     {
-                        fs::path algoPublicKeyFile =
-                            algoDir / PUBLICKEY_FILE_NAME;
-                        fs::path algoSigFile =
-                            algoDir / (optionalImage + ".sig");
-
-                        if (fs::exists(algoSigFile, ec))
+                        error("MLDSA signatures missing");
+                        return false;
+                    }
+                    else
+                    {
+                        bool algoValid =
+                            verifyFile(file, algoSigFile, algoPublicKeyFile,
+                                       pqAlgorithm->hashType);
+                        if (!algoValid)
                         {
-                            bool algoValid =
-                                verifyFile(file, algoSigFile, algoPublicKeyFile,
-                                           pqAlgorithm->hashType);
-                            if (!algoValid)
-                            {
-                                error(
-                                    "Signature validation failed for optional image {IMAGE} with {ALGO}",
-                                    "IMAGE", optionalImage, "ALGO",
-                                    pqAlgorithm->name);
-                                return false;
-                            }
+                            error(
+                                "Signature validation failed for optional image {IMAGE} with {ALGO}",
+                                "IMAGE", optionalImage, "ALGO",
+                                pqAlgorithm->name);
+                            return false;
                         }
                     }
                 }
@@ -400,7 +410,7 @@ bool Signature::systemLevelVerify()
 
                         if (!fs::exists(algoDir, ec))
                         {
-                            break; // RSA passed, PQ optional
+                            return false;
                         }
 
                         // Check if system has corresponding key
@@ -410,7 +420,7 @@ bool Signature::systemLevelVerify()
 
                         if (!fs::exists(systemAlgoKeyPath, ec))
                         {
-                            break; // RSA passed, PQ optional
+                            return false;
                         }
 
                         fs::path algoManifestSig = algoDir / MANIFEST_FILE_NAME;
@@ -617,17 +627,12 @@ bool Signature::checkAndVerifyImage(
 
 bool Signature::verifyPQSignatures(const std::vector<std::string>& imageList)
 {
-    if (!pqAlgorithm.has_value())
-    {
-        return true; // No PQ algorithm, skip
-    }
-
     std::error_code ec;
     fs::path algoDir(imageDirPath / pqAlgorithm->name);
 
     if (!fs::exists(algoDir, ec))
     {
-        return true; // PQ directory doesn't exist, optional
+        return false;
     }
 
     fs::path algoPublicKeyFile = algoDir / PUBLICKEY_FILE_NAME;

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -220,6 +220,7 @@ class SignatureTest : public testing::Test
             manifestFile);
         command("echo \"HashType=RSA-SHA256\" >> " + manifestFile);
         command("echo \"KeyType=OpenBMC\" >> " + manifestFile);
+        command("echo \"MLDSA_Hash_Type=SHA-256,MLDSA\" >> " + manifestFile);
 
         std::string kernelFile = extractPath.string() + "/" + "image-kernel";
         command("echo \"image-kernel file \" > " + kernelFile);
@@ -255,6 +256,36 @@ class SignatureTest : public testing::Test
         command(opensslCmd + pkeyFile + " -out " + pubkeyFile + ".sig " +
                 pubkeyFile);
 
+        // Create MLDSA directory and signatures
+        std::string mldsaDir = extractPath.string() + "/MLDSA";
+        command("mkdir -p " + mldsaDir);
+
+        std::string mldsaPkeyFile = mldsaDir + "/private.pem";
+        command("openssl genrsa -out " + mldsaPkeyFile + " 2048");
+
+        std::string mldsaPubkeyFile = mldsaDir + "/publickey";
+        command("openssl rsa -in " + mldsaPkeyFile + " -outform PEM " +
+                "-pubout -out " + mldsaPubkeyFile);
+
+        std::string opensslSHA3Cmd = "openssl dgst -sha256 -sign ";
+        command(opensslSHA3Cmd + mldsaPkeyFile + " -out " + mldsaDir +
+                "/image-kernel.sig " + kernelFile);
+        command(opensslSHA3Cmd + mldsaPkeyFile + " -out " + mldsaDir +
+                "/MANIFEST.sig " + manifestFile);
+        command(opensslSHA3Cmd + mldsaPkeyFile + " -out " + mldsaDir +
+                "/image-rofs.sig " + rofsFile);
+        command(opensslSHA3Cmd + mldsaPkeyFile + " -out " + mldsaDir +
+                "/image-rwfs.sig " + rwfsFile);
+        command(opensslSHA3Cmd + mldsaPkeyFile + " -out " + mldsaDir +
+                "/image-u-boot.sig " + ubootFile);
+
+        command(opensslSHA3Cmd + mldsaPkeyFile + " -out " + mldsaDir +
+                "/publickey.sig " + pubkeyFile);
+
+        std::string systemMLDSAPath = signedConfOpenBMCPath.string() + "/MLDSA";
+        command("mkdir -p " + systemMLDSAPath);
+        command("cp " + mldsaPubkeyFile + " " + systemMLDSAPath);
+
 #ifdef WANT_SIGNATURE_VERIFY
         std::string fullFile = extractPath.string() + "/" + "image-full";
         command("cat " + kernelFile + ".sig " + rofsFile + ".sig " + rwfsFile +
@@ -262,6 +293,9 @@ class SignatureTest : public testing::Test
                 pubkeyFile + ".sig > " + fullFile);
         command(opensslCmd + pkeyFile + " -out " + fullFile + ".sig " +
                 fullFile);
+
+        command(opensslSHA3Cmd + mldsaPkeyFile + " -out " + mldsaDir +
+                "/image-full.sig " + fullFile);
 #endif
 
         signature = std::make_unique<Signature>(extractPath, signedConfPath);
@@ -341,6 +375,13 @@ TEST_F(SignatureTest, TestNoFullSignatureForBIOS)
     command("sed -i s/VersionPurpose.BMC/VersionPurpose.BIOS/ " + manifestFile);
     command(opensslCmd + pkeyFile + " -out " + manifestFile + ".sig " +
             manifestFile);
+
+    // Re-sign MANIFEST with MLDSA key
+    std::string mldsaDir = extractPath.string() + "/MLDSA";
+    std::string mldsaPkeyFile = mldsaDir + "/private.pem";
+    std::string opensslSHA256Cmd = "openssl dgst -sha256 -sign ";
+    command(opensslSHA256Cmd + mldsaPkeyFile + " -out " + mldsaDir +
+            "/MANIFEST.sig " + manifestFile);
 
     // Re-create signature object and make sure verify succeed.
     signature = std::make_unique<Signature>(extractPath, signedConfPath);


### PR DESCRIPTION
All BMC firmware images must now include ML-DSA signatures also.
Images without ML-DSA signatures will be rejected.

Tested by:
Verified images with RSA + MLDSA signatures are accepted 
Verified images with RSA only signatures are rejected

Upstream : Downstream only