### PR TITLE
Fix the MLDSA signature validation

### DIFF
--- a/image_verify.cpp
+++ b/image_verify.cpp
@@ -83,7 +83,10 @@ AvailableKeyTypes Signature::getAvailableKeyTypesFromSystem() const
             // extract the key types
             // /etc/activationdata/OpenBMC/  -> get OpenBMC from the path
             auto key = p.path().parent_path();
-            keyTypes.insert(key.filename());
+            if (key.parent_path() == signedConfPath)
+            {
+                keyTypes.insert(key.filename());
+            }
         }
     }
 
@@ -479,9 +482,6 @@ bool Signature::verifyFile(const fs::path& file, const fs::path& sigFile,
         elog<InternalFailure>();
     }
 
-    // Initializes a digest context.
-    EVP_MD_CTX_Ptr verifyCtx(EVP_MD_CTX_new(), ::EVP_MD_CTX_free);
-
     // Adds all digest algorithms to the internal table
     OpenSSL_add_all_digests();
 
@@ -494,50 +494,116 @@ bool Signature::verifyFile(const fs::path& file, const fs::path& sigFile,
         elog<InternalFailure>();
     }
 
-    auto result = EVP_DigestVerifyInit(verifyCtx.get(), nullptr, hashStruct,
-                                       nullptr, publicKeyPtr.get());
-
-    if (result <= 0)
-    {
-        error("Error ({RC}) occurred during EVP_DigestVerifyInit", "RC",
-              ERR_get_error());
-        elog<InternalFailure>();
-    }
-
-    // Hash the data file and update the verification context
     auto size = fs::file_size(file, ec);
     auto dataPtr = mapFile(file, size);
 
-    result = EVP_DigestVerifyUpdate(verifyCtx.get(), dataPtr(), size);
-    if (result <= 0)
+    auto sigSize = fs::file_size(sigFile, ec);
+    auto signature = mapFile(sigFile, sigSize);
+
+    if (isMLDSAKey(publicKeyPtr.get()))
     {
-        error("Error ({RC}) occurred during EVP_DigestVerifyUpdate", "RC",
-              ERR_get_error());
-        elog<InternalFailure>();
+        EVP_MD_CTX_Ptr hashCtx(EVP_MD_CTX_new(), ::EVP_MD_CTX_free);
+
+        if (EVP_DigestInit_ex(hashCtx.get(), hashStruct, nullptr) != 1)
+        {
+            error("Error ({RC}) occurred during EVP_DigestInit_ex", "RC",
+                  ERR_get_error());
+            elog<InternalFailure>();
+        }
+
+        if (EVP_DigestUpdate(hashCtx.get(), dataPtr(), size) != 1)
+        {
+            error("Error ({RC}) occurred during EVP_DigestUpdate", "RC",
+                  ERR_get_error());
+            elog<InternalFailure>();
+        }
+
+        unsigned char hash[EVP_MAX_MD_SIZE];
+        unsigned int hashLen = 0;
+
+        if (EVP_DigestFinal_ex(hashCtx.get(), hash, &hashLen) != 1)
+        {
+            error("Error ({RC}) occurred during EVP_DigestFinal_ex", "RC",
+                  ERR_get_error());
+            elog<InternalFailure>();
+        }
+
+        EVP_MD_CTX_Ptr verifyCtx(EVP_MD_CTX_new(), ::EVP_MD_CTX_free);
+        auto result = EVP_DigestVerifyInit(verifyCtx.get(), nullptr, nullptr,
+                                           nullptr, publicKeyPtr.get());
+        if (result <= 0)
+        {
+            error("Error ({RC}) occurred during EVP_DigestVerifyInit", "RC",
+                  ERR_get_error());
+            elog<InternalFailure>();
+        }
+
+        result = EVP_DigestVerify(verifyCtx.get(),
+                                  reinterpret_cast<unsigned char*>(signature()),
+                                  sigSize, hash, hashLen);
+
+        if (result < 0)
+        {
+            error("Error ({RC}) occurred during EVP_DigestVerify", "RC",
+                  ERR_get_error());
+            elog<InternalFailure>();
+        }
+
+        if (result == 0)
+        {
+            error(
+                "EVP_DigestVerify: ML-DSA signature validation failed on {PATH}",
+                "PATH", sigFile);
+            return false;
+        }
+
+        return true;
     }
-
-    // Verify the data with signature.
-    size = fs::file_size(sigFile, ec);
-    auto signature = mapFile(sigFile, size);
-
-    result = EVP_DigestVerifyFinal(
-        verifyCtx.get(), reinterpret_cast<unsigned char*>(signature()), size);
-
-    // Check the verification result.
-    if (result < 0)
+    else
     {
-        error("Error ({RC}) occurred during EVP_DigestVerifyFinal", "RC",
-              ERR_get_error());
-        elog<InternalFailure>();
-    }
+        // Initializes a digest context.
+        EVP_MD_CTX_Ptr verifyCtx(EVP_MD_CTX_new(), ::EVP_MD_CTX_free);
 
-    if (result == 0)
-    {
-        error("EVP_DigestVerifyFinal:Signature validation failed on {PATH}",
-              "PATH", sigFile);
-        return false;
+        auto result = EVP_DigestVerifyInit(verifyCtx.get(), nullptr, hashStruct,
+                                           nullptr, publicKeyPtr.get());
+
+        if (result <= 0)
+        {
+            error("Error ({RC}) occurred during EVP_DigestVerifyInit", "RC",
+                  ERR_get_error());
+            elog<InternalFailure>();
+        }
+
+        // Hash the data file and update the verification context
+        result = EVP_DigestVerifyUpdate(verifyCtx.get(), dataPtr(), size);
+        if (result <= 0)
+        {
+            error("Error ({RC}) occurred during EVP_DigestVerifyUpdate", "RC",
+                  ERR_get_error());
+            elog<InternalFailure>();
+        }
+
+        // Verify the data with signature.
+        result = EVP_DigestVerifyFinal(
+            verifyCtx.get(), reinterpret_cast<unsigned char*>(signature()),
+            sigSize);
+
+        // Check the verification result.
+        if (result < 0)
+        {
+            error("Error ({RC}) occurred during EVP_DigestVerifyFinal", "RC",
+                  ERR_get_error());
+            elog<InternalFailure>();
+        }
+
+        if (result == 0)
+        {
+            error("EVP_DigestVerifyFinal:Signature validation failed on {PATH}",
+                  "PATH", sigFile);
+            return false;
+        }
+        return true;
     }
-    return true;
 }
 
 inline EVP_PKEY_Ptr Signature::createPublicKey(const fs::path& publicKey)
@@ -615,6 +681,25 @@ bool Signature::checkAndVerifyImage(
     return valid;
 }
 
+inline bool Signature::isMLDSAKey(const EVP_PKEY* pkey)
+{
+    if (!pkey)
+    {
+        return false;
+    }
+
+    // Check the key type name to identify ML-DSA keys
+    const char* keyTypeName = EVP_PKEY_get0_type_name(pkey);
+    if (keyTypeName != nullptr)
+    {
+        std::string typeStr(keyTypeName);
+        return (typeStr.find("ML-DSA") != std::string::npos ||
+                typeStr.find("MLDSA") != std::string::npos);
+    }
+
+    return false;
+}
+
 bool Signature::verifyPQSignatures(const std::vector<std::string>& imageList)
 {
     if (!pqAlgorithm.has_value())
@@ -627,7 +712,8 @@ bool Signature::verifyPQSignatures(const std::vector<std::string>& imageList)
 
     if (!fs::exists(algoDir, ec))
     {
-        return true; // PQ directory doesn't exist, optional
+        error("ML-DSA specified in MANIFEST but directory not found");
+        return false;
     }
 
     fs::path algoPublicKeyFile = algoDir / PUBLICKEY_FILE_NAME;

--- a/image_verify.hpp
+++ b/image_verify.hpp
@@ -266,6 +266,13 @@ class Signature
      * failure
      */
     bool verifyPQSignatures(const std::vector<std::string>& imageList);
+
+    /**
+     * @brief Check if the given public key is an ML-DSA key
+     * @param[in]  - EVP_PKEY pointer
+     * @return true if ML-DSA key, false otherwise
+     */
+    static inline bool isMLDSAKey(const EVP_PKEY* pkey);
 };
 
 } // namespace image


### PR DESCRIPTION
Fix the MLDSA signature validation.

Tested:
    Backward compatibility of the existing code update
    Verified the new signatures are verified when present.

Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-bmc-code-mgmt/+/88286
Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=769303