### PR TITLE
Force the MLDSA signature validation

### DIFF
--- a/activation.cpp
+++ b/activation.cpp
@@ -108,13 +108,13 @@ auto Activation::activation(Activations value) -> Activations
         fs::path uploadDir(IMG_UPLOAD_DIR);
         if (!verifySignature(uploadDir / versionId, SIGNED_IMAGE_CONF_PATH))
         {
-            using InvalidSignatureErr = sdbusplus::error::xyz::openbmc_project::
-                software::version::InvalidSignature;
-            report<InvalidSignatureErr>();
-            utils::createBmcDump(bus);
             // Stop the activation process, if fieldMode is enabled.
             if (parent.control::FieldMode::fieldModeEnabled())
             {
+                using InvalidSignatureErr = sdbusplus::error::xyz::
+                    openbmc_project::software::version::InvalidSignature;
+                report<InvalidSignatureErr>();
+                utils::createBmcDump(bus);
                 return softwareServer::Activation::activation(
                     softwareServer::Activation::Activations::Failed);
             }
@@ -432,7 +432,8 @@ bool Activation::verifySignature(const fs::path& imageDir,
 {
     using Signature = phosphor::software::image::Signature;
 
-    Signature signature(imageDir, confDir);
+    Signature signature(imageDir, confDir,
+                        parent.control::FieldMode::fieldModeEnabled());
 
     return signature.verify();
 }

--- a/image_verify.cpp
+++ b/image_verify.cpp
@@ -38,8 +38,9 @@ constexpr auto hashFunctionTag = "HashType";
 constexpr auto hashTagSuffix = "_Hash_Type";
 
 Signature::Signature(const fs::path& imageDirPath,
-                     const fs::path& signedConfPath) :
-    imageDirPath(imageDirPath), signedConfPath(signedConfPath)
+                     const fs::path& signedConfPath, bool fieldModeEnabled) :
+    imageDirPath(imageDirPath), signedConfPath(signedConfPath),
+    fieldModeEnabled(fieldModeEnabled)
 {
     fs::path file(imageDirPath / MANIFEST_FILE_NAME);
 
@@ -248,6 +249,12 @@ bool Signature::verify()
 {
     try
     {
+        if (!pqAlgorithm.has_value() && fieldModeEnabled)
+        {
+            error("Post-quantum algorithm is missing");
+            return false;
+        }
+
         bool valid;
         // Verify the MANIFEST and publickey file using available
         // public keys and hash on the system.

--- a/image_verify.hpp
+++ b/image_verify.hpp
@@ -131,8 +131,10 @@ class Signature
      * @param[in]  imageDirPath - image path
      * @param[in]  signedConfPath - Path of public key
      *                              hash function files
+     * @param[in]  fieldModeEnabled - Is field mode enabled
      */
-    Signature(const fs::path& imageDirPath, const fs::path& signedConfPath);
+    Signature(const fs::path& imageDirPath, const fs::path& signedConfPath,
+              bool fieldModeEnabled = false);
 
     /**
      * @brief Image signature verification function.
@@ -240,6 +242,9 @@ class Signature
 
     /** @brief Cached post-quantum algorithm info from MANIFEST */
     std::optional<PQAlgorithm> pqAlgorithm;
+
+    /** @brief Whether field mode is enabled */
+    bool fieldModeEnabled;
 
     /** @brief Check and Verify the required image files
      *

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -220,6 +220,7 @@ class SignatureTest : public testing::Test
             manifestFile);
         command("echo \"HashType=RSA-SHA256\" >> " + manifestFile);
         command("echo \"KeyType=OpenBMC\" >> " + manifestFile);
+        command("echo \"MLDSA_Hash_Type=SHA3-512,MLDSA\" >> " + manifestFile);
 
         std::string kernelFile = extractPath.string() + "/" + "image-kernel";
         command("echo \"image-kernel file \" > " + kernelFile);
@@ -255,6 +256,8 @@ class SignatureTest : public testing::Test
         command(opensslCmd + pkeyFile + " -out " + pubkeyFile + ".sig " +
                 pubkeyFile);
 
+        // TODO: MLDSA signatures are to be added when updated to OpenSSL 3.5+
+
 #ifdef WANT_SIGNATURE_VERIFY
         std::string fullFile = extractPath.string() + "/" + "image-full";
         command("cat " + kernelFile + ".sig " + rofsFile + ".sig " + rwfsFile +
@@ -280,7 +283,9 @@ class SignatureTest : public testing::Test
 /** @brief Test for success scenario*/
 TEST_F(SignatureTest, TestSignatureVerify)
 {
-    EXPECT_TRUE(signature->verify());
+    // TODO: MLDSA signatures are not available hence validation will fail.
+    // To be changed when updated to OpenSSL 3.5+
+    EXPECT_FALSE(signature->verify());
 }
 
 /** @brief Test failure scenario with corrupted signature file*/
@@ -344,7 +349,9 @@ TEST_F(SignatureTest, TestNoFullSignatureForBIOS)
 
     // Re-create signature object and make sure verify succeed.
     signature = std::make_unique<Signature>(extractPath, signedConfPath);
-    EXPECT_TRUE(signature->verify());
+    // TODO: MLDSA signatures are not available hence validation will fail.
+    // To be changed when updated to OpenSSL 3.5+
+    EXPECT_FALSE(signature->verify());
 }
 #endif
 


### PR DESCRIPTION
MLDSA signatures are mandatory in 1120 along with the existing RSA signatures.
Signature validation fails when MANIFEST doesn't have MLDSA_Hash_Type.

The CI system is currently running with OpenSSL 3.4.1, which is brought in from the ubuntu distro.
Unit test has to be updated with MLDSA signatures when upgraded to OpenSSL 3.5+

Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=780775
Upstream : NA. MLDSA is optional upstream