### PR TITLE
Fix the MLDSA signature validation

### DIFF
--- a/image_verify.cpp
+++ b/image_verify.cpp
@@ -67,6 +67,8 @@ AvailableKeyTypes Signature::getAvailableKeyTypesFromSystem() const
         elog<InternalFailure>();
     }
 
+    mldsakeyType.reset();
+
     // Look for all the hash and public key file names get the key value
     // For example:
     // /etc/activationdata/OpenBMC/publickey
@@ -83,9 +85,20 @@ AvailableKeyTypes Signature::getAvailableKeyTypesFromSystem() const
             // extract the key types
             // /etc/activationdata/OpenBMC/  -> get OpenBMC from the path
             auto key = p.path().parent_path();
-            if (key.parent_path() == signedConfPath)
+            if (fs::equivalent(key.parent_path(), signedConfPath, ec))
             {
-                keyTypes.insert(key.filename());
+                std::string keyTypeName = key.filename().string();
+                keyTypes.insert(keyTypeName);
+                if (!mldsakeyType.has_value())
+                {
+                    std::string lowerName = keyTypeName;
+                    std::transform(lowerName.begin(), lowerName.end(),
+                                   lowerName.begin(), ::tolower);
+                    if (lowerName.find("mldsa") != std::string::npos)
+                    {
+                        mldsakeyType = keyTypeName;
+                    }
+                }
             }
         }
     }
@@ -406,9 +419,14 @@ bool Signature::systemLevelVerify()
                             break; // RSA passed, PQ optional
                         }
 
+                        if (!mldsakeyType.has_value())
+                        {
+                            break;
+                        }
+
                         // Check if system has corresponding key
                         fs::path systemAlgoKeyPath =
-                            signedConfPath / keyType / pqAlgorithm->name /
+                            signedConfPath / mldsakeyType.value() /
                             PUBLICKEY_FILE_NAME;
 
                         if (!fs::exists(systemAlgoKeyPath, ec))

--- a/image_verify.hpp
+++ b/image_verify.hpp
@@ -273,6 +273,9 @@ class Signature
      * @return true if ML-DSA key, false otherwise
      */
     static inline bool isMLDSAKey(const EVP_PKEY* pkey);
+
+    /** @brief Name of the ML-DSA key type found during system scan */
+    mutable std::optional<std::string> mldsakeyType;
 };
 
 } // namespace image


### PR DESCRIPTION
Fix the expected folder structure in /etc/activationdata

Tested:
    Backward compatibility of the existing code update
    Verified the new signatures are verified when present.

Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=769303
Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-bmc-code-mgmt/+/88286
Change-Id: Icb178aac27d69a7dc430786ca9aa7d53ae7a0aea