### PR TITLE
Optimise the signature validation

### DIFF
--- a/image_verify.cpp
+++ b/image_verify.cpp
@@ -88,16 +88,16 @@ AvailableKeyTypes Signature::getAvailableKeyTypesFromSystem() const
             if (fs::equivalent(key.parent_path(), signedConfPath, ec))
             {
                 std::string keyTypeName = key.filename().string();
-                keyTypes.insert(keyTypeName);
-                if (!mldsakeyType.has_value())
+                std::string lowerName = keyTypeName;
+                std::transform(lowerName.begin(), lowerName.end(),
+                               lowerName.begin(), ::tolower);
+                if (lowerName.find("mldsa") != std::string::npos)
                 {
-                    std::string lowerName = keyTypeName;
-                    std::transform(lowerName.begin(), lowerName.end(),
-                                   lowerName.begin(), ::tolower);
-                    if (lowerName.find("mldsa") != std::string::npos)
-                    {
-                        mldsakeyType = keyTypeName;
-                    }
+                    mldsakeyType = keyTypeName;
+                }
+                else
+                {
+                    keyTypes.insert(keyTypeName);
                 }
             }
         }


### PR DESCRIPTION
Avoid MLDSA key to get added to keyTypes to avoid unnecessary iteration 

Tested:
    Backward compatibility of the existing code update
    Verified the new signatures are verified when present.
    
Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-bmc-code-mgmt/+/88286

Change-Id: Icb178aac27d69a7dc430786ca9aa7d53ae7a0aea