### PR TITLE
Support storing FW image as part of code update

### DIFF
--- a/activation.cpp
+++ b/activation.cpp
@@ -283,6 +283,9 @@ void Activation::onFlashWriteSuccess()
     auto flashId = parent.versions.find(versionId)->second->path();
     storePurpose(flashId, parent.versions.find(versionId)->second->purpose());
 
+    // Move tarball backup to flash bank
+    createTarballBackup(true, flashId);
+
     if (!redundancyPriority)
     {
         redundancyPriority =

--- a/image_manager.cpp
+++ b/image_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "image_manager.hpp"
 
+#include "serialize.hpp"
 #include "version.hpp"
 #include "watch.hpp"
 
@@ -40,6 +41,7 @@ using ManifestFail = Software::image::ManifestFileFailure;
 using UnTarFail = Software::image::UnTarFailure;
 using InternalFail = Software::image::InternalFailure;
 using ImageFail = Software::image::ImageFailure;
+namespace serialize = phosphor::software::updater;
 namespace fs = std::filesystem;
 
 struct RemovablePath
@@ -258,8 +260,12 @@ int Manager::processImage(const std::string& tarFilePath)
     auto allSoftwareObjs = getSoftwareObjects(bus);
     auto it =
         std::find(allSoftwareObjs.begin(), allSoftwareObjs.end(), objPath);
+
     if (versions.find(id) == versions.end() && it == allSoftwareObjs.end())
     {
+        // Copy tarball file to persist dir
+        serialize::createTarballBackup(false, "", tarFilePath);
+
         // Rename the temp dir to image dir
         fs::rename(tmpDirPath, imageDirPath, ec);
         // Clear the path, so it does not attemp to remove a non-existing path

--- a/meson.build
+++ b/meson.build
@@ -297,6 +297,7 @@ executable(
     'phosphor-version-software-manager',
     'image_manager.cpp',
     'image_manager_main.cpp',
+    'serialize.cpp',
     'version.cpp',
     'watch.cpp',
     software_manager_common_sources,

--- a/serialize.cpp
+++ b/serialize.cpp
@@ -22,6 +22,61 @@ namespace fs = std::filesystem;
 
 const std::string priorityName = "priority";
 const std::string purposeName = "purpose";
+const std::string tarballBackupName = "tarball_backup";
+const std::string tarballFileName = "tarball_backup.tar";
+
+const auto initialBackupPath = fs::path(PERSIST_DIR) / tarballBackupName;
+
+void createTarballBackup(bool deleteInitialBackup, const std::string& flashId,
+                         fs::path source)
+{
+    std::error_code ec;
+    fs::path dest;
+
+    if (deleteInitialBackup)
+    {
+        source = initialBackupPath / tarballFileName;
+        // Store tarball in flash bank
+        dest = fs::path(PERSIST_DIR) / flashId;
+    }
+    else
+    {
+        dest = initialBackupPath;
+    }
+
+    if (!fs::exists(source, ec))
+    {
+        error("Tarball file does not exist");
+        return;
+    }
+    if (!fs::is_directory(dest, ec))
+    {
+        fs::create_directories(dest, ec);
+    }
+
+    dest = dest / tarballFileName;
+
+    try
+    {
+        fs::copy_file(source, dest, fs::copy_options::overwrite_existing, ec);
+        if (ec)
+        {
+            error("Failed to copy tarball to {DEST}: {ERROR}", "DEST", dest,
+                  "ERROR", ec.message());
+        }
+        else
+        {
+            if (deleteInitialBackup)
+            {
+                fs::remove_all(initialBackupPath, ec);
+            }
+        }
+    }
+    catch (const fs::filesystem_error& e)
+    {
+        error("Error while copying file: {ERROR}", "ERROR", e);
+    }
+}
 
 void storePriority(const std::string& flashId, uint8_t priority)
 {

--- a/serialize.hpp
+++ b/serialize.hpp
@@ -4,6 +4,7 @@
 
 #include "version.hpp"
 
+#include <filesystem>
 #include <string>
 
 namespace phosphor
@@ -13,8 +14,20 @@ namespace software
 namespace updater
 {
 
+namespace fs = std::filesystem;
+
 using VersionPurpose =
     sdbusplus::server::xyz::openbmc_project::software::Version::VersionPurpose;
+
+/**
+ *  @brief Creates a persistent backup of the tarball.
+ *  @param[in] deleteInitialBackup - If true, initial backup is deleted.
+ *  @param[in] flashId - The flash id of the version for which to store
+ *                       information.
+ *  @param[in] source - Source directory of tarball for initial backup.
+ **/
+void createTarballBackup(bool deleteInitialBackup,
+                         const std::string& flashId = "", fs::path source = "");
 
 /** @brief Serialization function - stores priority information to file
  *  @param[in] flashId - The flash id of the version for which to store


### PR DESCRIPTION
Store tarball backup when new image is uploaded and move tarball backup to flash bank after activation.

Tested: Verified backup of tarball is successful during code update via SIMICS.

Signed off by: Niveetha Wijendran <niveetha.wijendran@ibm.com>