### PR TITLE
Run usb update service after bmc state manager

### DIFF
--- a/bmc/usb/services/usb-code-update@.service
+++ b/bmc/usb/services/usb-code-update@.service
@@ -5,6 +5,7 @@ After=dev-%i.device
 After=xyz.openbmc_project.Software.Version.service
 After=xyz.openbmc_project.Software.BMC.Updater.service
 After=xyz.openbmc_project.Software.Manager.service
+After=xyz.openbmc_project.State.BMC.service
 
 [Service]
 Restart=no


### PR DESCRIPTION
On rbmc system, usb code update service resulted in: 
"Error in mapper method call for (/xyz/openbmc_project/state/bmc0, xyz.openbmc_project.State.BMC: sd_bus_call:
xyz.openbmc_project.Common.Error.ResourceNotFound: The resource is not found."

It was found that usb code update service is dependent on bmc state manager.
