### PR TITLE
activation: Only create Update object for new code update method

### DIFF
--- a/bmc/activation.cpp
+++ b/bmc/activation.cpp
@@ -315,8 +315,11 @@ void Activation::onFlashWriteSuccess()
         info("BMC image ready; need reboot to get activated.");
     }
 
-    // Create Update Object for this version.
-    parent.createUpdateObject(versionId, path);
+    if (parent.useUpdateDBusInterface)
+    {
+        // Create Update Object for this version.
+        parent.createUpdateObject(versionId, path);
+    }
 
     activation(softwareServer::Activation::Activations::Active);
 }


### PR DESCRIPTION
Updated onFlashWriteSuccess to only create the Update object when using the new code update method. Upstream changes from the rebase created an Update object after image activation. This triggered PLDM to run the rename event again, resulting in the bootside not switching after code update.

Tested: Verified the rename event does not occur after image activation and that code update is successful in SIMICS.
